### PR TITLE
feat: ゲームロジックとユーザー認証の改善

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -11,13 +11,14 @@ import { Server, Socket } from "socket.io";
 import { parse } from "cookie";
 import { JwtService } from "@nestjs/jwt";
 import { GameService } from "./game.service";
-import { PaddleMoveDto } from "../../../shared/game.interface";
 import { corsConfig } from "../cors.config";
 
-// userId を保持する拡張型
 interface AuthenticatedSocket extends Socket {
 	data: {
-		userId?: number;
+		user: {
+			id: number;
+			username?: string;
+		};
 	};
 }
 
@@ -34,7 +35,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		private readonly jwtService: JwtService,
 	) {}
 
-	// WebSocket 接続時に一度だけ認証し、userId を client.data に保存する
+	// WebSocket 接続時に一度だけ認証し、user を client.data に保存する
 	// これにより各イベントハンドラで毎回 Cookie を読み直す必要がなくなる
 	handleConnection(client: AuthenticatedSocket) {
 		const cookieHeader = client.handshake.headers.cookie;
@@ -55,9 +56,9 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
 		try {
 			const payload = this.jwtService.verify<{ sub: number }>(token);
-			client.data.userId = payload.sub;
+			client.data.user = { id: payload.sub };
 			console.log(
-				`[GameGateway] 接続認証OK userId=${client.data.userId} (socket=${client.id})`,
+				`[GameGateway] 接続認証OK userId=${client.data.user.id} (socket=${client.id})`,
 			);
 		} catch (err) {
 			console.warn(
@@ -68,33 +69,55 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		}
 	}
 
-	// 1. マッチメイキング待ち列に参加
+	@SubscribeMessage("joinAIGame")
+	handleJoinAIGame(@ConnectedSocket() client: AuthenticatedSocket) {
+		const userId = client.data.user.id;
+		console.log(`[GameGateway] joinAIGame: ${userId}`);
+		this.gameService.createAIGame(client, userId, this.server);
+	}
+
 	@SubscribeMessage("joinQueue")
 	handleJoinQueue(@ConnectedSocket() client: AuthenticatedSocket) {
-		const userId = client.data.userId;
+		const userId = client.data.user.id;
 		console.log(
 			`[GameGateway] joinQueue userId=${userId} (socket=${client.id})`,
 		);
 		this.gameService.addToQueue(client, this.server, userId);
 	}
 
-	// 2. パドル操作
-	@SubscribeMessage("movePaddle")
-	handleMove(
-		@ConnectedSocket() client: Socket,
-		@MessageBody() data: PaddleMoveDto,
-	) {
-		if (!data || typeof data.y !== "number" || !isFinite(data.y)) {
-			return;
-		}
-		this.gameService.updatePaddle(client.id, data.y);
+	@SubscribeMessage("moveUp")
+	handleMoveUp(@ConnectedSocket() client: AuthenticatedSocket) {
+		const userId = client.data.user.id;
+		this.gameService.movePaddleUp(userId);
 	}
 
-	// 3. 切断
+	@SubscribeMessage("moveDown")
+	handleMoveDown(@ConnectedSocket() client: AuthenticatedSocket) {
+		const userId = client.data.user.id;
+		this.gameService.movePaddleDown(userId);
+	}
+
 	handleDisconnect(client: AuthenticatedSocket) {
-		console.log(
-			`[GameGateway] 切断 userId=${client.data.userId} (socket=${client.id})`,
-		);
-		this.gameService.handleDisconnect(client, this.server);
+		const userId = client.data?.user?.id;
+		if (!userId) return;
+		console.log(`[GameGateway] 切断 userId=${userId} (socket=${client.id})`);
+		this.gameService.handleDisconnect(client, this.server, userId);
+	}
+
+	@SubscribeMessage("reconnectGame")
+	handleReconnect(
+		@ConnectedSocket() client: AuthenticatedSocket,
+		@MessageBody() data: { roomId: string },
+	) {
+		const userId = client.data.user.id;
+		console.log(`[GameGateway] Reconnecting: ${userId}`);
+		this.gameService.handleReconnect(client, data.roomId, this.server, userId);
+	}
+
+	@SubscribeMessage("surrender")
+	handleSurrender(@ConnectedSocket() client: AuthenticatedSocket) {
+		const userId = client.data.user.id;
+		console.log(`[GameGateway] Surrendering: ${userId}`);
+		this.gameService.handleSurrender(this.server, userId);
 	}
 }

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -4,12 +4,13 @@ import { JwtModule } from "@nestjs/jwt";
 import { GameGateway } from "./game.gateway";
 import { GameService } from "./game.service";
 import { MatchHistory } from "./match-history.entity";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
 	imports: [
 		// 試合結果を保存するために MatchHistory エンティティを登録
 		TypeOrmModule.forFeature([MatchHistory]),
-		// ゲートウェイでJWTを検証するために必要
+		AuthModule,
 		JwtModule.register({
 			secret: process.env.JWT_SECRET || "fallback-jwt-secret",
 		}),

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -3,7 +3,8 @@ import { Socket, Server } from "socket.io";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { MatchHistory } from "./match-history.entity";
-import { GameState } from "../../../shared/game.interface";
+import { GameState, GameStateDto } from "../../../shared/game.interface";
+import { randomUUID } from "crypto";
 import {
 	FIELD_WIDTH,
 	FIELD_HEIGHT,
@@ -14,23 +15,28 @@ import {
 	RIGHTPAD_LEFTMOST,
 	RIGHTPAD_RIGHTMOST,
 	STARTING_POSITION,
-	UPPER_LIMIT,
 	SPEED_BASE,
 	SPEED_CHANGE,
 	MAX_SCORE,
 	ANGLE_CHANGE,
 	PAD_SPEED,
-} from "./game.constants";
+	AI_SOCKET_ID,
+	AI_USER_ID,
+	GRACE_TIME,
+} from "../../../shared/game.constants";
 
 // サーバー内部でのみ管理する物理パラメータ（フロントには送らない）
 interface GameInternalState extends GameState {
+	roomId: string;
 	dx: number;
 	dy: number;
-	p1Id: string;
-	p2Id: string;
-	p1UserId?: number; // 認証済みユーザーのDB ID（統計用）
-	p2UserId?: number;
+	p1SocketId: string;
+	p2SocketId: string;
+	p1UserId: number; // 認証済みユーザーのDB ID（統計用）
+	p2UserId: number;
 	interval: NodeJS.Timeout | null;
+	disconnectTimer?: NodeJS.Timeout | null;
+	disconnectedPlayerId?: number;
 }
 
 @Injectable()
@@ -40,26 +46,185 @@ export class GameService {
 		private readonly matchHistoryRepository: Repository<MatchHistory>,
 	) {}
 
-	private games = new Map<string, GameInternalState>();
 	// キューにユーザーIDも一緒に保持する
-	private queue: { socket: Socket; userId?: number }[] = [];
+	private queue: { socket: Socket; userId: number }[] = [];
+	private AIgames = new Map<string, GameInternalState>();
+	private games = new Map<string, GameInternalState>();
+
+	// faster operations on movepaddle etc
+	// movepddleとか早く調べれるように
+	private userIdToRoom = new Map<number, string>();
+
+	// faster handleing of disconnections and reconnections
+	// reconnectionとか早く調べれるように
+	private socketToPlayer = new Map<string, number>();
+
+	private toDto(game: GameInternalState): GameStateDto {
+		return {
+			roomId: game.roomId,
+			state: {
+				ball: game.ball,
+				leftPaddleY: game.leftPaddleY,
+				rightPaddleY: game.rightPaddleY,
+				leftScore: game.leftScore,
+				rightScore: game.rightScore,
+				isPaused: game.isPaused,
+			},
+		};
+	}
+
+	createAIGame(client: Socket, playerId: number, server: Server) {
+		const roomId = `room_${randomUUID()}`;
+		console.log(
+			`[Game.Service] CreateAIgame for player ${playerId} in room number ${roomId}`,
+		);
+		client.join(roomId);
+
+		const initialState: GameInternalState = {
+			roomId: roomId,
+			ball: { ...FIELD_CENTER },
+			leftPaddleY: STARTING_POSITION,
+			rightPaddleY: STARTING_POSITION,
+			leftScore: 0,
+			rightScore: 0,
+			isPaused: false,
+			dx: SPEED_BASE,
+			dy: SPEED_BASE,
+			p1SocketId: client.id,
+			p2SocketId: AI_SOCKET_ID,
+			p1UserId: playerId,
+			p2UserId: AI_USER_ID,
+			interval: null,
+		};
+
+		const interval = setInterval(() => {
+			this.AIgameLoop(roomId, server);
+		}, 1000 / 60);
+
+		initialState.interval = interval;
+		this.AIgames.set(roomId, initialState);
+		this.userIdToRoom.set(playerId, roomId);
+		this.socketToPlayer.set(client.id, playerId);
+		console.log(
+			`[Game.Service] Successfully starting AIgame for player ${playerId} in room number ${roomId}`,
+		);
+	}
+
+	// ほとんどgameloopと同じにですけど、DBにセーブしてません
+	private AIgameLoop(roomId: string, server: Server) {
+		const game = this.AIgames.get(roomId);
+		if (!game || game.isPaused) return;
+
+		// 1. ball movement
+		game.ball.x += game.dx;
+		game.ball.y += game.dy;
+
+		// 2. up and down bounce
+		if (
+			(game.dy < 0 && game.ball.y <= 0) ||
+			(game.dy > 0 && game.ball.y >= FIELD_HEIGHT)
+		) {
+			game.dy *= -1;
+		}
+
+		// 3. player paddle collision
+		if (
+			game.dx < 0 &&
+			game.ball.x <= LEFTPAD_RIGHTMOST &&
+			game.ball.x >= LEFTPAD_LEFTMOST
+		) {
+			if (
+				game.ball.y >= game.leftPaddleY &&
+				game.ball.y <= game.leftPaddleY + PAD_LENGTH
+			) {
+				const hitPos = (game.ball.y - game.leftPaddleY) / PAD_LENGTH;
+				game.dy = (hitPos - 0.5) * ANGLE_CHANGE;
+				game.dx *= SPEED_CHANGE;
+			}
+		}
+
+		// 4. AI paddle behavior (provvisory)
+		const aiSpeed = 3;
+		if (game.dx > 0) {
+			if (game.ball.y > game.rightPaddleY + PAD_LENGTH / 2) {
+				game.rightPaddleY = Math.min(
+					FIELD_HEIGHT - PAD_LENGTH,
+					game.rightPaddleY + aiSpeed,
+				);
+			} else {
+				game.rightPaddleY = Math.max(0, game.rightPaddleY - aiSpeed);
+			}
+
+			// AI paddle collision
+			if (
+				game.ball.x >= RIGHTPAD_LEFTMOST &&
+				game.ball.x <= RIGHTPAD_RIGHTMOST
+			) {
+				if (
+					game.ball.y >= game.rightPaddleY &&
+					game.ball.y <= game.rightPaddleY + PAD_LENGTH
+				) {
+					const hitPos = (game.ball.y - game.rightPaddleY) / PAD_LENGTH;
+					game.dy = (hitPos - 0.5) * ANGLE_CHANGE;
+					game.dx *= SPEED_CHANGE;
+				}
+			}
+		}
+
+		// 5. check for goal
+		if (game.ball.x <= 0 || game.ball.x >= FIELD_WIDTH) {
+			if (game.ball.x <= 0) game.rightScore++;
+			else game.leftScore++;
+
+			game.ball = { ...FIELD_CENTER };
+			game.dx = game.dx > 0 ? -SPEED_BASE : SPEED_BASE;
+			game.dy = SPEED_BASE;
+		}
+
+		// 6. check for gameover
+		//	on gameover, we are sending the socketId of the winner like in the online case,
+		//	in the front, please remember to check the AI_SOCKET_ID in the shared/game.constants
+		if (game.leftScore >= MAX_SCORE || game.rightScore >= MAX_SCORE) {
+			clearInterval(game.interval);
+
+			const winnerSocketId =
+				game.leftScore >= MAX_SCORE ? game.p1SocketId : game.p2SocketId;
+
+			console.log(
+				`[Game.Service] AIgameOver. winnerSocketId->${winnerSocketId}`,
+			);
+			server.to(roomId).emit("gameOver", { winner: winnerSocketId, roomId });
+			// not saving result for aiGames
+			this.AIgames.delete(roomId);
+			this.userIdToRoom.delete(game.p1UserId);
+			this.socketToPlayer.delete(game.p1SocketId);
+			return;
+		}
+
+		server.to(roomId).emit("updateState", this.toDto(game));
+	}
 
 	// マッチメイキング
-	addToQueue(client: Socket, server: Server, userId?: number) {
-		console.log(`[Game] Player joined queue: ${client.id} (userId: ${userId})`);
+	addToQueue(client: Socket, server: Server, userId: number) {
+		console.log(`[Game.Service] addToQueue: ${userId}`);
 
-		if (this.queue.find((q) => q.socket.id === client.id)) return;
+		if (
+			this.queue.find((q) => q.socket.id === client.id) ||
+			this.queue.find((q) => q.userId === userId)
+		) {
+			console.log(`[Game.Service] user was already in queue: ${userId}`);
+			return;
+		}
 		this.queue.push({ socket: client, userId });
 		console.log(
-			"Queue:",
-			this.queue.map((q) => q.socket.id),
+			"[Game.Service] Queue: ",
+			this.queue.map((q) => q.userId),
 		);
 
 		if (this.queue.length >= 2) {
-			console.log(`[Game] Match found! Starting game...`);
 			const p1 = this.queue.shift()!;
 			const p2 = this.queue.shift()!;
-			const roomId = `room_${p1.socket.id}`;
+			const roomId = `room_${randomUUID()}`;
 
 			p1.socket.join(roomId);
 			p2.socket.join(roomId);
@@ -72,19 +237,23 @@ export class GameService {
 				p1.userId,
 				p2.userId,
 			);
+			console.log(
+				`[Game.Service] Match found! Starting game for players ${p1.userId} and ${p2.userId} in room number ${roomId}`,
+			);
 		}
 	}
 
 	// ゲームの初期化
 	initGame(
 		roomId: string,
-		p1Id: string,
-		p2Id: string,
+		p1SocketId: string,
+		p2SocketId: string,
 		server: Server,
-		p1UserId?: number,
-		p2UserId?: number,
+		p1UserId: number,
+		p2UserId: number,
 	) {
 		const initialState: GameInternalState = {
+			roomId: roomId,
 			ball: { ...FIELD_CENTER },
 			leftPaddleY: STARTING_POSITION,
 			rightPaddleY: STARTING_POSITION,
@@ -93,8 +262,8 @@ export class GameService {
 			isPaused: false,
 			dx: SPEED_BASE,
 			dy: SPEED_BASE,
-			p1Id,
-			p2Id,
+			p1SocketId,
+			p2SocketId,
 			p1UserId,
 			p2UserId,
 			interval: null,
@@ -107,11 +276,15 @@ export class GameService {
 		initialState.interval = interval;
 
 		this.games.set(roomId, initialState);
+		if (p1UserId) this.userIdToRoom.set(p1UserId, roomId);
+		if (p2UserId) this.userIdToRoom.set(p2UserId, roomId);
+		this.socketToPlayer.set(p1SocketId, p1UserId);
+		this.socketToPlayer.set(p2SocketId, p2UserId);
 	}
 
 	private gameLoop(roomId: string, server: Server) {
 		const game = this.games.get(roomId);
-		if (!game) return;
+		if (!game || game.isPaused) return;
 
 		// 1. ボールの移動
 		game.ball.x += game.dx;
@@ -170,48 +343,37 @@ export class GameService {
 		// 5. 終了判定とDB保存
 		if (game.leftScore >= MAX_SCORE || game.rightScore >= MAX_SCORE) {
 			clearInterval(game.interval);
+			if (game.disconnectTimer) clearTimeout(game.disconnectTimer);
 
 			const isP1Winner = game.leftScore >= MAX_SCORE;
-			const winnerId = isP1Winner ? game.p1Id : game.p2Id;
+			const winnerSocketId = isP1Winner ? game.p1SocketId : game.p2SocketId;
 			const winnerUserId = isP1Winner ? game.p1UserId : game.p2UserId;
 			const loserUserId = isP1Winner ? game.p2UserId : game.p1UserId;
 			const winnerScore = Math.max(game.leftScore, game.rightScore);
 			const loserScore = Math.min(game.leftScore, game.rightScore);
 
 			// 最終スコアを送信（11点を反映）
-			/* eslint-disable @typescript-eslint/no-unused-vars */
-			const {
-				dx,
-				dy,
-				p1Id,
-				p2Id,
-				p1UserId,
-				p2UserId,
-				interval,
-				...finalState
-			} = game;
-			/* eslint-enable @typescript-eslint/no-unused-vars */
-			server.to(roomId).emit("updateState", finalState);
+			server.to(roomId).emit("updateState", this.toDto(game));
 
 			// フロントエンドに終了を通知
-			server.to(roomId).emit("gameOver", { winner: winnerId });
+			server.to(roomId).emit("gameOver", { winner: winnerSocketId, roomId });
 
 			// DBへ試合結果を保存（非同期）
 			console.log(
-				`[MatchSaved] WinnerUser:${winnerUserId} (Socket:${winnerId}) vs LoserUser:${loserUserId}`,
+				`[Game.Service] saving result: Winner->${winnerUserId} Loser->${loserUserId}`,
 			);
 			this.saveMatchResult(winnerScore, loserScore, winnerUserId, loserUserId);
 
 			this.games.delete(roomId);
+			this.userIdToRoom.delete(game.p1UserId);
+			this.userIdToRoom.delete(game.p2UserId);
+			this.socketToPlayer.delete(game.p1SocketId);
+			this.socketToPlayer.delete(game.p2SocketId);
 			return;
 		}
 
 		// 6. 状態配信
-		/* eslint-disable @typescript-eslint/no-unused-vars */
-		const { dx, dy, p1Id, p2Id, p1UserId, p2UserId, interval, ...publicState } =
-			game;
-		/* eslint-enable @typescript-eslint/no-unused-vars */
-		server.to(roomId).emit("updateState", publicState);
+		server.to(roomId).emit("updateState", this.toDto(game));
 	}
 
 	// 試合結果をDBに保存する内部メソッド
@@ -235,69 +397,102 @@ export class GameService {
 		}
 	}
 
-	updatePaddle(playerId: string, y: number) {
-		//managing bad y
-		if (y < 0 || y > UPPER_LIMIT) {
-			console.error("[Game]怪しいｙが気まあしてアレンジします。");
-			if (y < 0) y = 0;
-			else y = UPPER_LIMIT;
-		}
-		for (const [, game] of this.games.entries()) {
-			// ★ roomId を消して「,」だけにする
-			if (game.p1Id === playerId) {
-				if (Math.abs(game.leftPaddleY - y) > PAD_SPEED) {
-					console.log(
-						"[GameService] WARNING: Pad早すぎてcheatかも。無視にします",
-					);
-					return;
-				}
-				game.leftPaddleY = y;
-				break;
-			} else if (game.p2Id === playerId) {
-				if (Math.abs(game.rightPaddleY - y) > PAD_SPEED) {
-					console.log(
-						"[GameService] WARNING: Pad早すぎてcheatかも。無視にします",
-					);
-					return;
-				}
-				game.rightPaddleY = y;
-				break;
-			}
+	movePaddleUp(playerId: number) {
+		const roomId = this.userIdToRoom.get(playerId);
+		if (!roomId) return;
+		const game = this.games.get(roomId) || this.AIgames.get(roomId);
+		if (!game) return;
+
+		if (game.p1UserId === playerId) {
+			game.leftPaddleY = Math.max(0, game.leftPaddleY - PAD_SPEED);
+		} else if (game.p2UserId === playerId) {
+			game.rightPaddleY = Math.max(0, game.rightPaddleY - PAD_SPEED);
 		}
 	}
 
-	handleDisconnect(client: Socket, server: Server) {
-		console.log(`[GameService] Handling disconnect: ${client.id}`);
+	movePaddleDown(playerId: number) {
+		const roomId = this.userIdToRoom.get(playerId);
+		if (!roomId) return;
+		const game = this.games.get(roomId) || this.AIgames.get(roomId);
+		if (!game) return;
 
-		// disconnected人をQueueから消す
-		this.queue = this.queue.filter((q) => q.socket.id !== client.id);
+		if (game.p1UserId === playerId) {
+			game.leftPaddleY = Math.min(
+				FIELD_HEIGHT - PAD_LENGTH,
+				game.leftPaddleY + PAD_SPEED,
+			);
+		} else if (game.p2UserId === playerId) {
+			game.rightPaddleY = Math.min(
+				FIELD_HEIGHT - PAD_LENGTH,
+				game.rightPaddleY + PAD_SPEED,
+			);
+		}
+	}
+
+	handleDisconnect(client: Socket, server: Server, userId: number) {
 		console.log(
-			"Queue:",
-			this.queue.map((q) => q.socket.id),
+			`[GameService] HandleDisconnect: socket->${client.id}, id->${userId}`,
 		);
 
-		// 試合中だったら。。。
-		for (const [roomId, game] of this.games.entries()) {
-			if (game.p1Id === client.id || game.p2Id === client.id) {
-				console.log(`[GameService] Player left match ${roomId}`);
+		// Removing from queue if not matched yet
+		// playerまだ待ってた倍、Queueから消すだけ
+		const queueIndex = this.queue.findIndex((q) => q.socket.id === client.id);
+		if (queueIndex !== -1) {
+			this.queue.splice(queueIndex, 1);
+			this.socketToPlayer.delete(client.id);
+			console.log(`[GameService] Player ${userId} removed from queue`);
+			return; // no need for reconnection logic
+		}
 
-				// 試合をストップ
+		this.socketToPlayer.delete(client.id);
+
+		// Check if player is in an online match
+		// Onlineだった倍
+		const roomId = this.userIdToRoom.get(userId);
+		if (roomId && this.games.has(roomId)) {
+			const game = this.games.get(roomId)!;
+
+			console.log(
+				`[GameService] Player ${userId} left match ${roomId}, waiting reconnection`,
+			);
+
+			game.isPaused = true;
+
+			const otherSocketId =
+				game.p1SocketId === client.id ? game.p2SocketId : game.p1SocketId;
+			server
+				.to(roomId)
+				.emit("playerDisconnected", { playerSocketId: client.id });
+
+			if (game.disconnectTimer) clearTimeout(game.disconnectTimer);
+
+			game.disconnectTimer = setTimeout(() => {
+				console.log(
+					`[GameService] Grace period expired for player ${userId}, ending match ${roomId}`,
+				);
+
 				clearInterval(game.interval);
+				game.interval = null;
 
-				const isP1 = game.p1Id === client.id;
-				const winnerId = isP1 ? game.p2Id : game.p1Id;
-				const winnerUserId = isP1 ? game.p2UserId : game.p1UserId;
-				const loserUserId = isP1 ? game.p1UserId : game.p2UserId;
+				const winnerSocketId = otherSocketId;
+				const loserSocketId = client.id;
 
-				// 試合終了の知らせ
 				server.to(roomId).emit("gameOver", {
-					winner: winnerId,
+					winner: winnerSocketId,
 					reason: "disconnect",
+					roomId,
 				});
 
-				// DBにセーブ
-				const winnerScore = MAX_SCORE;
-				const loserScore = isP1 ? game.leftScore : game.rightScore;
+				//saving in the DB
+				//DBにセーブ
+				const winnerUserId =
+					game.p1SocketId === winnerSocketId ? game.p1UserId : game.p2UserId;
+				const loserUserId =
+					game.p1SocketId === loserSocketId ? game.p1UserId : game.p2UserId;
+				const winnerScore =
+					game.p1SocketId === winnerSocketId ? game.leftScore : game.rightScore;
+				const loserScore =
+					game.p1SocketId === loserSocketId ? game.leftScore : game.rightScore;
 				this.saveMatchResult(
 					winnerScore,
 					loserScore,
@@ -305,9 +500,154 @@ export class GameService {
 					loserUserId,
 				);
 
+				console.log(
+					`[Game.Service] saving result: Winner->${winnerUserId} Loser->${loserUserId}`,
+				);
+
 				this.games.delete(roomId);
-				break;
-			}
+				this.userIdToRoom.delete(game.p1UserId);
+				this.userIdToRoom.delete(game.p2UserId);
+				this.socketToPlayer.delete(game.p1SocketId);
+				this.socketToPlayer.delete(game.p2SocketId);
+			}, GRACE_TIME);
+
+			return;
+		}
+
+		// AI matches (not waiting for reconnection)
+		// AIだった倍、Reconnect待たないで消します
+		if (roomId && this.AIgames.has(roomId)) {
+			const game = this.AIgames.get(roomId)!;
+			console.log(`[GameService] Player disconnected from AI game ${roomId}`);
+
+			if (game.interval) clearInterval(game.interval);
+			this.AIgames.delete(roomId);
+			this.userIdToRoom.delete(game.p1UserId);
+			this.socketToPlayer.delete(game.p1SocketId);
+
+			server.to(roomId).emit("gameOver", {
+				winner: AI_SOCKET_ID,
+				reason: "disconnectAI",
+				roomId,
+			});
+		}
+	}
+
+	handleReconnect(
+		client: Socket,
+		roomId: string,
+		server: Server,
+		userId: number,
+	) {
+		// roomId OK?
+		const game = this.games.get(roomId);
+		if (!game) {
+			client.emit("reconnectFailed", { reason: "game_not_found" });
+			return;
+		}
+
+		// userId OK?
+		const isP1 = game.p1UserId === userId;
+		const isP2 = game.p2UserId === userId;
+		if (!isP1 && !isP2) {
+			client.emit("reconnectFailed", { reason: "not_your_game" });
+			return;
+		}
+
+		if (!game.interval && !game.disconnectTimer) {
+			client.emit("reconnectFailed", { reason: "game_already_finished" });
+			return;
+		}
+		if (isP1) game.p1SocketId = client.id;
+		if (isP2) game.p2SocketId = client.id;
+
+		console.log(`[GameService] Player reconnected: ${client.id} in ${roomId}`);
+
+		// update the new socket for the reconnection
+		// Reconnnectの時にSocket変わっちゃうので、Updateしてます
+		this.socketToPlayer.set(client.id, userId);
+
+		// join the room again
+		// Joinやり直します
+		client.join(roomId);
+
+		// clear timer if still not clear
+		// ClearTimerリセット
+		if (game.disconnectTimer) {
+			clearTimeout(game.disconnectTimer);
+			game.disconnectTimer = null;
+		}
+
+		// resume game
+		// もう一度Gameをスタートします
+		game.isPaused = false;
+
+		// notify the other player
+		// 待ってた相手に知らせ送ります
+		server.to(roomId).emit("playerReconnected", { userId });
+
+		// re-send gamestate to the reconnected player
+		// 戻って来たPlayerに無くしちゃってたGamestateを贈り直します
+		client.emit("updateState", this.toDto(game));
+
+		// restart game loop if necessary
+		// Intervalがリスタートするべきな倍
+		if (!game.interval) {
+			game.interval = setInterval(
+				() => this.gameLoop(roomId, server),
+				1000 / 60,
+			);
+		}
+	}
+
+	handleSurrender(server: Server, userId: number) {
+		console.log(`[GameService] Player ${userId} surrendered`);
+		const roomId = this.userIdToRoom.get(userId);
+		if (!roomId) return;
+
+		const game = this.games.get(roomId) || this.AIgames.get(roomId);
+		if (!game) return;
+
+		if (game.interval) {
+			clearInterval(game.interval);
+			game.interval = null;
+		}
+		const isP1 = game.p1UserId === userId;
+
+		const winnerUserId = isP1 ? game.p2UserId : game.p1UserId;
+		const loserUserId = isP1 ? game.p1UserId : game.p2UserId;
+		const winnerScore = isP1 ? game.rightScore : game.leftScore;
+		const loserScore = isP1 ? game.leftScore : game.rightScore;
+		const winnerSocketId = isP1 ? game.p2SocketId : game.p1SocketId;
+
+		server.to(roomId).emit("gameOver", {
+			winner: winnerSocketId,
+			reason: "surrender",
+			roomId,
+		});
+
+		// online match
+		// Onlineだった倍
+		if (this.games.has(roomId)) {
+			this.saveMatchResult(winnerScore, loserScore, winnerUserId, loserUserId);
+
+			this.userIdToRoom.delete(winnerUserId);
+			this.userIdToRoom.delete(loserUserId);
+
+			this.socketToPlayer.delete(game.p1SocketId);
+			this.socketToPlayer.delete(game.p2SocketId);
+
+			this.games.delete(roomId);
+			return;
+		}
+
+		// AI match
+		// AIだった倍
+		if (this.AIgames.has(roomId)) {
+			this.userIdToRoom.delete(userId);
+			this.socketToPlayer.delete(game.p1SocketId);
+
+			this.AIgames.delete(roomId);
 		}
 	}
 }

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -36,7 +36,6 @@ interface GameInternalState extends GameState {
 	p2UserId: number;
 	interval: NodeJS.Timeout | null;
 	disconnectTimer?: NodeJS.Timeout | null;
-	disconnectedPlayerId?: number;
 }
 
 @Injectable()
@@ -49,7 +48,7 @@ export class GameService {
 	// キューにユーザーIDも一緒に保持する
 	private queue: { socket: Socket; userId: number }[] = [];
 	private AIgames = new Map<string, GameInternalState>();
-	private games = new Map<string, GameInternalState>();
+	private onlineGames = new Map<string, GameInternalState>();
 
 	// faster operations on movepaddle etc
 	// movepddleとか早く調べれるように
@@ -58,6 +57,9 @@ export class GameService {
 	// faster handleing of disconnections and reconnections
 	// reconnectionとか早く調べれるように
 	private socketToPlayer = new Map<string, number>();
+
+	//automatic reconnection
+	private disconnectedPlayers = new Set<number>();
 
 	private toDto(game: GameInternalState): GameStateDto {
 		return {
@@ -74,6 +76,12 @@ export class GameService {
 	}
 
 	createAIGame(client: Socket, playerId: number, server: Server) {
+		if (this.userIdToRoom.has(playerId)) {
+			console.log(
+				`[Game.Service] The player ${playerId} is already in a match`,
+			);
+			return;
+		}
 		const roomId = `room_${randomUUID()}`;
 		console.log(
 			`[Game.Service] CreateAIgame for player ${playerId} in room number ${roomId}`,
@@ -206,13 +214,25 @@ export class GameService {
 
 	// マッチメイキング
 	addToQueue(client: Socket, server: Server, userId: number) {
-		console.log(`[Game.Service] addToQueue: ${userId}`);
+		console.log(`[Game.Service] try addToQueue: ${userId}`);
 
 		if (
 			this.queue.find((q) => q.socket.id === client.id) ||
 			this.queue.find((q) => q.userId === userId)
 		) {
 			console.log(`[Game.Service] user was already in queue: ${userId}`);
+			return;
+		}
+		if (this.userIdToRoom.has(userId)) {
+			console.log(
+				`[Game.Service] The player ${userId} is already in a match. Try reconnection`,
+			);
+			this.handleReconnect(
+				client,
+				this.userIdToRoom.get(userId),
+				server,
+				userId,
+			);
 			return;
 		}
 		this.queue.push({ socket: client, userId });
@@ -275,7 +295,7 @@ export class GameService {
 
 		initialState.interval = interval;
 
-		this.games.set(roomId, initialState);
+		this.onlineGames.set(roomId, initialState);
 		if (p1UserId) this.userIdToRoom.set(p1UserId, roomId);
 		if (p2UserId) this.userIdToRoom.set(p2UserId, roomId);
 		this.socketToPlayer.set(p1SocketId, p1UserId);
@@ -283,7 +303,7 @@ export class GameService {
 	}
 
 	private gameLoop(roomId: string, server: Server) {
-		const game = this.games.get(roomId);
+		const game = this.onlineGames.get(roomId);
 		if (!game || game.isPaused) return;
 
 		// 1. ボールの移動
@@ -364,11 +384,13 @@ export class GameService {
 			);
 			this.saveMatchResult(winnerScore, loserScore, winnerUserId, loserUserId);
 
-			this.games.delete(roomId);
+			this.onlineGames.delete(roomId);
 			this.userIdToRoom.delete(game.p1UserId);
 			this.userIdToRoom.delete(game.p2UserId);
 			this.socketToPlayer.delete(game.p1SocketId);
 			this.socketToPlayer.delete(game.p2SocketId);
+			this.disconnectedPlayers.delete(game.p1UserId);
+			this.disconnectedPlayers.delete(game.p2UserId);
 			return;
 		}
 
@@ -400,7 +422,7 @@ export class GameService {
 	movePaddleUp(playerId: number) {
 		const roomId = this.userIdToRoom.get(playerId);
 		if (!roomId) return;
-		const game = this.games.get(roomId) || this.AIgames.get(roomId);
+		const game = this.onlineGames.get(roomId) || this.AIgames.get(roomId);
 		if (!game) return;
 
 		if (game.p1UserId === playerId) {
@@ -413,7 +435,7 @@ export class GameService {
 	movePaddleDown(playerId: number) {
 		const roomId = this.userIdToRoom.get(playerId);
 		if (!roomId) return;
-		const game = this.games.get(roomId) || this.AIgames.get(roomId);
+		const game = this.onlineGames.get(roomId) || this.AIgames.get(roomId);
 		if (!game) return;
 
 		if (game.p1UserId === playerId) {
@@ -449,20 +471,23 @@ export class GameService {
 		// Check if player is in an online match
 		// Onlineだった倍
 		const roomId = this.userIdToRoom.get(userId);
-		if (roomId && this.games.has(roomId)) {
-			const game = this.games.get(roomId)!;
+		if (roomId && this.onlineGames.has(roomId)) {
+			const game = this.onlineGames.get(roomId)!;
+			this.disconnectedPlayers.add(userId);
 
 			console.log(
 				`[GameService] Player ${userId} left match ${roomId}, waiting reconnection`,
+			);
+			console.log(
+				"[GameService] disconnectedPlayers ->",
+				Array.from(this.disconnectedPlayers),
 			);
 
 			game.isPaused = true;
 
 			const otherSocketId =
 				game.p1SocketId === client.id ? game.p2SocketId : game.p1SocketId;
-			server
-				.to(roomId)
-				.emit("playerDisconnected", { playerSocketId: client.id });
+			server.to(roomId).emit("playerDisconnected", { userId });
 
 			if (game.disconnectTimer) clearTimeout(game.disconnectTimer);
 
@@ -504,11 +529,14 @@ export class GameService {
 					`[Game.Service] saving result: Winner->${winnerUserId} Loser->${loserUserId}`,
 				);
 
-				this.games.delete(roomId);
+				this.onlineGames.delete(roomId);
 				this.userIdToRoom.delete(game.p1UserId);
 				this.userIdToRoom.delete(game.p2UserId);
 				this.socketToPlayer.delete(game.p1SocketId);
 				this.socketToPlayer.delete(game.p2SocketId);
+				// removing the disconnected player definitely
+				this.disconnectedPlayers.delete(winnerUserId);
+				this.disconnectedPlayers.delete(loserUserId);
 			}, GRACE_TIME);
 
 			return;
@@ -540,7 +568,7 @@ export class GameService {
 		userId: number,
 	) {
 		// roomId OK?
-		const game = this.games.get(roomId);
+		const game = this.onlineGames.get(roomId);
 		if (!game) {
 			client.emit("reconnectFailed", { reason: "game_not_found" });
 			return;
@@ -561,7 +589,10 @@ export class GameService {
 		if (isP1) game.p1SocketId = client.id;
 		if (isP2) game.p2SocketId = client.id;
 
-		console.log(`[GameService] Player reconnected: ${client.id} in ${roomId}`);
+		console.log(
+			`[GameService] Player ${userId} reconnected: new socket -> ${client.id} room-> ${roomId}`,
+		);
+		this.disconnectedPlayers.delete(userId);
 
 		// update the new socket for the reconnection
 		// Reconnnectの時にSocket変わっちゃうので、Updateしてます
@@ -605,7 +636,7 @@ export class GameService {
 		const roomId = this.userIdToRoom.get(userId);
 		if (!roomId) return;
 
-		const game = this.games.get(roomId) || this.AIgames.get(roomId);
+		const game = this.onlineGames.get(roomId) || this.AIgames.get(roomId);
 		if (!game) return;
 
 		if (game.interval) {
@@ -620,6 +651,8 @@ export class GameService {
 		const loserScore = isP1 ? game.leftScore : game.rightScore;
 		const winnerSocketId = isP1 ? game.p2SocketId : game.p1SocketId;
 
+		this.disconnectedPlayers.delete(userId);
+
 		server.to(roomId).emit("gameOver", {
 			winner: winnerSocketId,
 			reason: "surrender",
@@ -628,7 +661,7 @@ export class GameService {
 
 		// online match
 		// Onlineだった倍
-		if (this.games.has(roomId)) {
+		if (this.onlineGames.has(roomId)) {
 			this.saveMatchResult(winnerScore, loserScore, winnerUserId, loserUserId);
 
 			this.userIdToRoom.delete(winnerUserId);
@@ -637,7 +670,7 @@ export class GameService {
 			this.socketToPlayer.delete(game.p1SocketId);
 			this.socketToPlayer.delete(game.p2SocketId);
 
-			this.games.delete(roomId);
+			this.onlineGames.delete(roomId);
 			return;
 		}
 

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -9,7 +9,7 @@ import {
 	movePaddle,
 	disconnectGameSocket,
 } from "../services/gameSocket";
-import type { GameState } from "/shared/game.interface";
+import type { GameState, GameStateDto } from "/shared/game.interface";
 
 export type GameMode = "ai" | "online";
 
@@ -113,7 +113,8 @@ function GamePage({ mode, roomId, onBack }: GamePageProps) {
 		socket.on("connect", handleConnect);
 
 		// ゲーム状態の更新を受信（プレイヤー判定も行う）
-		const handleUpdateState = (state: GameState) => {
+		const handleUpdateState = (dto: GameStateDto) => {
+			const state = dto.state;
 			setGameState(state);
 
 			// まだプレイヤーが確定していない場合、パドルの応答で判定

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -1,15 +1,21 @@
-import { useEffect, useMemo, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import Pong from "@alexium216/react-pong";
 import PongCanvas from "./PongCanvas";
 import {
 	getGameSocket,
 	onUpdateState,
 	onGameOver,
-	movePaddle,
+	moveUp,
+	moveDown,
+	joinAIGame,
+	surrender,
 	disconnectGameSocket,
+	onPlayerDisconnected,
+	onPlayerReconnected,
+	onReconnectFailed,
 } from "../services/gameSocket";
 import type { GameState, GameStateDto } from "/shared/game.interface";
+import { AI_SOCKET_ID } from "/shared/game.constants";
 
 export type GameMode = "ai" | "online";
 
@@ -26,135 +32,117 @@ type GamePageProps = {
 	onBack?: () => void; // Onlineへ戻る（UI導線）
 };
 
-type PongSettings = {
-	width: number;
-	height: number;
-	ballSize: number;
-	paddleHeight: number;
-	paddleWidth: number;
-	paddleSpeed: number;
-	upArrow: string;
-	downArrow: string;
-};
-
-const DEFAULTS: PongSettings = {
-	width: 700,
-	height: 450,
-	ballSize: 10,
-	paddleHeight: 80,
-	paddleWidth: 10,
-	paddleSpeed: 7,
-	upArrow: "ArrowUp",
-	downArrow: "ArrowDown",
-};
-
-function clamp(n: number, min: number, max: number) {
-	return Math.max(min, Math.min(max, n));
-}
-
-function GamePage({ mode, roomId, onBack }: GamePageProps) {
+function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 	const { t } = useTranslation();
-	const [s, setS] = useState<PongSettings>(DEFAULTS);
 
-	// キャンバスカードのコンテナ幅を計測してレスポンシブスケールを算出
-	// 初期値0にすることで、ResizeObserver計測前の一瞬の表示崩れを防ぐ
-	const canvasCardRef = useRef<HTMLElement>(null);
-	const [containerWidth, setContainerWidth] = useState<number>(0);
-	useEffect(() => {
-		const el = canvasCardRef.current;
-		if (!el) return;
-		const ro = new ResizeObserver(([entry]) => {
-			setContainerWidth(entry.contentRect.width);
-		});
-		ro.observe(el);
-		return () => ro.disconnect();
-	}, []);
-
-	// オンラインモード用の状態
+	// ゲーム状態
 	const [gameState, setGameState] = useState<GameState | null>(null);
 	const [gameResult, setGameResult] = useState<{
-		winner: string;
+		winner: string | null;
 		isWinner: boolean;
+		reason?: string;
 	} | null>(null);
-	const [isPlayer1, setIsPlayer1] = useState<boolean | null>(null); // 自分が左パドルかどうか（null=未確定）
-	const lastSentPaddleY = useRef<number | null>(null); // 最後に送信したパドル位置（プレイヤー判定用）
+	const [isPaused, setIsPaused] = useState(false);
+	const [pauseMessage, setPauseMessage] = useState<string>("");
 
-	// AIモード用のprops（元サイズで動作、見た目のスケールはCSS transformで処理）
-	const pongProps = useMemo(
-		() => ({
-			width: s.width,
-			height: s.height,
-			ballSize: s.ballSize,
-			paddleHeight: s.paddleHeight,
-			paddleWidth: s.paddleWidth,
-			paddleSpeed: s.paddleSpeed,
-			upArrow: s.upArrow,
-			downArrow: s.downArrow,
-		}),
-		[s],
-	);
+	// 再接続用にroomIdを保持
+	const roomIdRef = useRef<string | null>(initialRoomId ?? null);
 
-	// CSSスケール: コンテナ幅に収まるよう縮小率を計算（0=計測前は非表示）
-	const pongScale =
-		containerWidth > 0 ? Math.min(1, containerWidth / s.width) : 0;
-
-	// オンラインモードのWebSocket接続
+	// WebSocket接続とイベントハンドリング
 	useEffect(() => {
-		if (mode !== "online") return;
-
 		const socket = getGameSocket();
 
-		// 接続時に自分のIDを確認して、player1かplayer2かを判定
-		// 注意: バックエンドは最初にjoinQueueしたプレイヤーがp1（左パドル）
 		const handleConnect = () => {
 			console.log("[GamePage] WebSocket接続成功");
 		};
-
 		socket.on("connect", handleConnect);
 
-		// ゲーム状態の更新を受信（プレイヤー判定も行う）
-		const handleUpdateState = (dto: GameStateDto) => {
-			const state = dto.state;
-			setGameState(state);
+		// AI対戦の場合、接続完了後にjoinAIGameを送信
+		if (mode === "ai") {
+			if (socket.connected) {
+				joinAIGame();
+			} else {
+				socket.once("connect", () => {
+					joinAIGame();
+				});
+			}
+		}
 
-			// まだプレイヤーが確定していない場合、パドルの応答で判定
-			if (isPlayer1 === null && lastSentPaddleY.current !== null) {
-				const tolerance = 5; // 誤差許容
-				if (Math.abs(state.leftPaddleY - lastSentPaddleY.current) < tolerance) {
-					console.log("[GamePage] Player 1 (左パドル) と判定");
-					setIsPlayer1(true);
-				} else if (
-					Math.abs(state.rightPaddleY - lastSentPaddleY.current) < tolerance
-				) {
-					console.log("[GamePage] Player 2 (右パドル) と判定");
-					setIsPlayer1(false);
-				}
+		// ゲーム状態の更新を受信
+		const handleUpdateState = (dto: GameStateDto) => {
+			setGameState(dto.state);
+			// roomIdを保存（再接続に使用）
+			roomIdRef.current = dto.roomId;
+			// 一時停止解除
+			if (isPaused) {
+				setIsPaused(false);
+				setPauseMessage("");
 			}
 		};
 		onUpdateState(handleUpdateState);
 
 		// ゲーム終了を受信
-		const handleGameOver = (data: { winner: string }) => {
+		const handleGameOver = (data: {
+			winner: string | null;
+			roomId: string;
+			reason?: string;
+		}) => {
 			console.log("[GamePage] ゲーム終了:", data);
 			const myId = socket.id;
+			const isWinner =
+				data.winner === myId || (mode === "ai" && data.winner !== AI_SOCKET_ID);
 			setGameResult({
 				winner: data.winner,
-				isWinner: data.winner === myId,
+				isWinner,
+				reason: data.reason,
 			});
 		};
 		onGameOver(handleGameOver);
+
+		// 対戦相手の切断通知
+		const handlePlayerDisconnected = () => {
+			console.log("[GamePage] 対戦相手が切断");
+			setIsPaused(true);
+			setPauseMessage(t("game.opponentDisconnected"));
+		};
+		onPlayerDisconnected(handlePlayerDisconnected);
+
+		// 対戦相手の再接続通知
+		const handlePlayerReconnected = () => {
+			console.log("[GamePage] 対戦相手が再接続");
+			setIsPaused(false);
+			setPauseMessage("");
+		};
+		onPlayerReconnected(handlePlayerReconnected);
+
+		// 再接続失敗の通知
+		const handleReconnectFailed = (data: { reason: string }) => {
+			console.log("[GamePage] 再接続失敗:", data.reason);
+		};
+		onReconnectFailed(handleReconnectFailed);
 
 		return () => {
 			socket.off("connect", handleConnect);
 			socket.off("updateState", handleUpdateState);
 			socket.off("gameOver", handleGameOver);
+			socket.off("playerDisconnected", handlePlayerDisconnected);
+			socket.off("playerReconnected", handlePlayerReconnected);
+			socket.off("reconnectFailed", handleReconnectFailed);
 		};
-	}, [mode, roomId, isPlayer1]);
+	}, [mode, isPaused]);
 
-	// パドル移動をサーバーに送信（プレイヤー判定用に位置を記録）
-	const handlePaddleMove = useCallback((y: number) => {
-		lastSentPaddleY.current = y;
-		movePaddle(y);
+	// パドル操作コールバック
+	const handleMoveUp = useCallback(() => {
+		moveUp();
+	}, []);
+
+	const handleMoveDown = useCallback(() => {
+		moveDown();
+	}, []);
+
+	// 降参
+	const handleSurrender = useCallback(() => {
+		surrender();
 	}, []);
 
 	// ゲームを終了してOnlinePageに戻る
@@ -177,222 +165,106 @@ function GamePage({ mode, roomId, onBack }: GamePageProps) {
 				</div>
 
 				<div style={{ display: "flex", gap: 8 }}>
+					{!gameResult && gameState && (
+						<button
+							type="button"
+							className="btn-secondary"
+							onClick={handleSurrender}
+						>
+							{t("game.surrender")}
+						</button>
+					)}
 					{onBack && (
 						<button
 							type="button"
-							className="btn btn-secondary"
-							onClick={mode === "online" ? handleBackToOnline : onBack}
+							className="btn-secondary"
+							onClick={handleBackToOnline}
 						>
 							{t("game.back")}
-						</button>
-					)}
-					{mode === "ai" && (
-						<button
-							type="button"
-							className="btn btn-primary"
-							onClick={() => setS(DEFAULTS)}
-						>
-							{t("game.reset")}
 						</button>
 					)}
 				</div>
 			</header>
 
 			<div className="game-layout">
-				<section className="game-canvas-card" ref={canvasCardRef}>
-					{mode === "online" ? (
-						<>
-							{/* オンラインモード：カスタムCanvas */}
-							<PongCanvas
-								gameState={gameState}
-								onPaddleMove={handlePaddleMove}
-								isPlayer1={isPlayer1}
-								autoFocus
-							/>
+				<section className="game-canvas-card">
+					<PongCanvas
+						gameState={gameState}
+						onMoveUp={handleMoveUp}
+						onMoveDown={handleMoveDown}
+						isPlayer1={null}
+						autoFocus
+					/>
 
-							{/* ゲーム結果表示 */}
-							{gameResult && (
-								<div
-									style={{
-										position: "absolute",
-										top: "50%",
-										left: "50%",
-										transform: "translate(-50%, -50%)",
-										background: "rgba(0,0,0,0.9)",
-										padding: "32px 48px",
-										borderRadius: "16px",
-										textAlign: "center",
-										zIndex: 10,
-									}}
-								>
-									<h2
-										style={{
-											color: gameResult.isWinner ? "#00ff88" : "#ff4444",
-											margin: 0,
-										}}
-									>
-										{gameResult.isWinner ? t("game.youWin") : t("game.youLose")}
-									</h2>
-									<p style={{ color: "#aaa", marginTop: 8 }}>
-										{gameState?.leftScore} - {gameState?.rightScore}
-									</p>
-									<button
-										type="button"
-										onClick={handleBackToOnline}
-										style={{ marginTop: 16 }}
-									>
-										{t("game.backToOnline")}
-									</button>
-								</div>
-							)}
-						</>
-					) : (
-						/* AIモード：react-pongライブラリ
-						 * ゲームロジックは元サイズ(s.width×s.height)で動作し、
-						 * CSS transformで視覚的にコンテナ幅に収める */
+					{/* 一時停止オーバーレイ */}
+					{isPaused && (
 						<div
 							style={{
-								width: s.width * pongScale,
-								height: s.height * pongScale,
-								overflow: "hidden",
+								position: "absolute",
+								top: "50%",
+								left: "50%",
+								transform: "translate(-50%, -50%)",
+								background: "rgba(0,0,0,0.8)",
+								padding: "24px 40px",
+								borderRadius: "16px",
+								textAlign: "center",
+								zIndex: 10,
 							}}
 						>
-							<div
+							<h3 style={{ color: "#ffaa00", margin: 0 }}>{pauseMessage}</h3>
+							<p style={{ color: "#aaa", marginTop: 8 }}>
+								{t("game.waitingForReconnect")}
+							</p>
+						</div>
+					)}
+
+					{/* ゲーム結果表示 */}
+					{gameResult && (
+						<div
+							style={{
+								position: "absolute",
+								top: "50%",
+								left: "50%",
+								transform: "translate(-50%, -50%)",
+								background: "rgba(0,0,0,0.9)",
+								padding: "32px 48px",
+								borderRadius: "16px",
+								textAlign: "center",
+								zIndex: 10,
+							}}
+						>
+							<h2
 								style={{
-									position: "relative",
-									width: s.width,
-									height: s.height,
-									transform: `scale(${pongScale})`,
-									transformOrigin: "top left",
+									color: gameResult.isWinner ? "#00ff88" : "#ff4444",
+									margin: 0,
 								}}
 							>
-								<Pong key={JSON.stringify(pongProps)} {...pongProps} />
-							</div>
+								{gameResult.isWinner ? t("game.youWin") : t("game.youLose")}
+							</h2>
+							{gameResult.reason && (
+								<p style={{ color: "#888", marginTop: 4, fontSize: 14 }}>
+									({gameResult.reason})
+								</p>
+							)}
+							<p style={{ color: "#aaa", marginTop: 8 }}>
+								{gameState?.leftScore} - {gameState?.rightScore}
+							</p>
+							<button
+								type="button"
+								onClick={handleBackToOnline}
+								style={{ marginTop: 16 }}
+							>
+								{t("game.backToOnline")}
+							</button>
 						</div>
 					)}
 				</section>
 
 				<aside className="game-side-panel">
-					{mode === "ai" && (
-						<>
-							<h3>{t("game.settings")}</h3>
-
-							<label className="slider-row">
-								<div className="slider-label">
-									{t("game.width")}: {s.width}
-								</div>
-								<input
-									className="slider-input"
-									type="range"
-									min={480}
-									max={980}
-									step={10}
-									value={s.width}
-									onChange={(e) =>
-										setS((p) => ({ ...p, width: Number(e.target.value) }))
-									}
-								/>
-							</label>
-
-							<label className="slider-row">
-								<div className="slider-label">
-									{t("game.height")}: {s.height}
-								</div>
-								<input
-									className="slider-input"
-									type="range"
-									min={320}
-									max={700}
-									step={10}
-									value={s.height}
-									onChange={(e) =>
-										setS((p) => ({ ...p, height: Number(e.target.value) }))
-									}
-								/>
-							</label>
-
-							<label className="slider-row">
-								<div className="slider-label">
-									{t("game.ballSize")}: {s.ballSize}
-								</div>
-								<input
-									className="slider-input"
-									type="range"
-									min={6}
-									max={24}
-									step={1}
-									value={s.ballSize}
-									onChange={(e) =>
-										setS((p) => ({ ...p, ballSize: Number(e.target.value) }))
-									}
-								/>
-							</label>
-
-							<label className="slider-row">
-								<div className="slider-label">
-									{t("game.paddleHeight")}: {s.paddleHeight}
-								</div>
-								<input
-									className="slider-input"
-									type="range"
-									min={40}
-									max={180}
-									step={5}
-									value={s.paddleHeight}
-									onChange={(e) =>
-										setS((p) => ({
-											...p,
-											paddleHeight: Number(e.target.value),
-										}))
-									}
-								/>
-							</label>
-
-							<label className="slider-row">
-								<div className="slider-label">
-									{t("game.paddleWidth")}: {s.paddleWidth}
-								</div>
-								<input
-									className="slider-input"
-									type="range"
-									min={6}
-									max={30}
-									step={1}
-									value={s.paddleWidth}
-									onChange={(e) =>
-										setS((p) => ({ ...p, paddleWidth: Number(e.target.value) }))
-									}
-								/>
-							</label>
-
-							<label className="slider-row">
-								<div className="slider-label">
-									{t("game.paddleSpeed")}: {s.paddleSpeed}
-								</div>
-								<input
-									className="slider-input"
-									type="range"
-									min={2}
-									max={20}
-									step={1}
-									value={s.paddleSpeed}
-									onChange={(e) =>
-										setS((p) => ({
-											...p,
-											paddleSpeed: clamp(Number(e.target.value), 1, 50),
-										}))
-									}
-								/>
-							</label>
-
-							<hr />
-
-							<h3>{t("game.controls")}</h3>
-							<p style={{ marginTop: 0 }}>
-								<code>↑ W</code> / <code>↓ S</code>
-							</p>
-						</>
-					)}
+					<h3>{t("game.controls")}</h3>
+					<p style={{ marginTop: 0 }}>
+						<code>↑ W</code> / <code>↓ S</code>
+					</p>
 				</aside>
 			</div>
 		</div>

--- a/frontend/src/components/OnlinePage.tsx
+++ b/frontend/src/components/OnlinePage.tsx
@@ -6,6 +6,7 @@ import {
 	onUpdateState,
 	disconnectGameSocket,
 } from "../services/gameSocket";
+import type { GameStateDto } from "/shared/game.interface";
 
 type OnlineStatus = "idle" | "matching" | "error";
 
@@ -48,12 +49,11 @@ export default function OnlinePage({ onStart }: OnlinePageProps) {
 		};
 
 		// updateStateを受信 = マッチング成立 & ゲーム開始
-		const handleUpdateState = () => {
+		const handleUpdateState = (dto: GameStateDto) => {
 			console.log("[OnlinePage] ゲーム状態受信 → 即座にゲーム画面へ遷移");
 			if (onStartRef.current) {
-				const roomId = `game-${Date.now()}`;
 				const opponent: Opponent = { username: "対戦相手" };
-				onStartRef.current({ roomId, opponent });
+				onStartRef.current({ roomId: dto.roomId, opponent });
 			}
 		};
 

--- a/frontend/src/components/PongCanvas.tsx
+++ b/frontend/src/components/PongCanvas.tsx
@@ -1,23 +1,26 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { GameState } from "/shared/game.interface";
+import {
+	FIELD_WIDTH,
+	FIELD_HEIGHT,
+	PAD_WIDTH,
+	PAD_LENGTH,
+	PAD_BORDER_DIST,
+} from "/shared/game.constants";
 
-// バックエンドと同じ定数（game.service.ts参照）
-// 座標系は固定のまま、CSSスケーリングでレスポンシブ対応
-const CANVAS_WIDTH = 800;
-const CANVAS_HEIGHT = 600;
+// 表示用の定数
 const MAX_DISPLAY_WIDTH = 640; // 表示上の最大幅
-const PADDLE_WIDTH = 20;
-const PADDLE_HEIGHT = 100;
 const BALL_RADIUS = 10;
 
-// パドル位置（バックエンドの衝突判定に合わせる）
-const LEFT_PADDLE_X = 40;
-const RIGHT_PADDLE_X = 740;
+// パドルのX座標（shared定数から算出）
+const LEFT_PADDLE_X = PAD_BORDER_DIST;
+const RIGHT_PADDLE_X = FIELD_WIDTH - PAD_BORDER_DIST;
 
 type PongCanvasProps = {
 	gameState: GameState | null;
-	onPaddleMove: (y: number) => void;
+	onMoveUp: () => void;
+	onMoveDown: () => void;
 	isPlayer1: boolean | null; // true: 左パドル, false: 右パドル, null: 未確定（両方白）
 	autoFocus?: boolean; // ゲーム開始時に自動フォーカス
 };
@@ -29,14 +32,14 @@ type PongCanvasProps = {
  */
 export default function PongCanvas({
 	gameState,
-	onPaddleMove,
+	onMoveUp,
+	onMoveDown,
 	isPlayer1,
 	autoFocus = false,
 }: PongCanvasProps) {
 	const { t } = useTranslation();
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
-	const paddleYRef = useRef<number>(250); // 自分のパドルY座標（送信用）
 	const keysPressed = useRef<Set<string>>(new Set()); // 押されているキーを追跡
 	const hasAutoFocused = useRef(false); // 自動フォーカス済みかどうか
 	const [isFocused, setIsFocused] = useState(false);
@@ -53,7 +56,7 @@ export default function PongCanvas({
 				container.parentElement?.clientWidth ?? MAX_DISPLAY_WIDTH,
 				MAX_DISPLAY_WIDTH,
 			);
-			const newScale = Math.min(1, availableWidth / CANVAS_WIDTH);
+			const newScale = Math.min(1, availableWidth / FIELD_WIDTH);
 			setScale(newScale);
 		};
 
@@ -76,7 +79,6 @@ export default function PongCanvas({
 	}, [autoFocus, gameState]);
 
 	// Canvasがフォーカスを持っているとき、ページスクロールを防止
-	// (React合成イベントはCanvas要素にフォーカスがないと発火しないため、windowレベルで監視)
 	useEffect(() => {
 		const preventScroll = (e: KeyboardEvent) => {
 			if (isFocused && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
@@ -91,10 +93,10 @@ export default function PongCanvas({
 	// キー押下時: キーをSetに追加（リピートイベントは無視）
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLCanvasElement>) => {
-			if (e.repeat) return; // OSのキーリピートは無視
+			if (e.repeat) return;
 			const validKeys = ["ArrowUp", "ArrowDown", "w", "W", "s", "S"];
 			if (validKeys.includes(e.key)) {
-				e.preventDefault(); // ページスクロールを防止
+				e.preventDefault();
 				keysPressed.current.add(e.key);
 			}
 		},
@@ -109,27 +111,20 @@ export default function PongCanvas({
 		[],
 	);
 
-	// 毎フレームでキー状態をチェックしてパドルを移動（フォーカス時のみ）
+	// 毎フレームでキー状態をチェックしてmoveUp/moveDownをサーバーに送信（フォーカス時のみ）
 	useEffect(() => {
 		if (!isFocused) return;
 
 		let animationId: number;
-		const moveSpeed = 8; // フレームあたりの移動量
 
 		const gameLoop = () => {
 			const keys = keysPressed.current;
-			let newY = paddleYRef.current;
 
 			if (keys.has("ArrowUp") || keys.has("w") || keys.has("W")) {
-				newY = Math.max(0, newY - moveSpeed);
+				onMoveUp();
 			}
 			if (keys.has("ArrowDown") || keys.has("s") || keys.has("S")) {
-				newY = Math.min(CANVAS_HEIGHT - PADDLE_HEIGHT, newY + moveSpeed);
-			}
-
-			if (newY !== paddleYRef.current) {
-				paddleYRef.current = newY;
-				onPaddleMove(newY);
+				onMoveDown();
 			}
 
 			animationId = requestAnimationFrame(gameLoop);
@@ -137,7 +132,7 @@ export default function PongCanvas({
 
 		animationId = requestAnimationFrame(gameLoop);
 		return () => cancelAnimationFrame(animationId);
-	}, [isFocused, onPaddleMove]);
+	}, [isFocused, onMoveUp, onMoveDown]);
 
 	// Canvas要素をクリックしたら自動的にフォーカス
 	const handleClick = useCallback(() => {
@@ -154,18 +149,14 @@ export default function PongCanvas({
 
 		// 背景をクリア（黒）
 		ctx.fillStyle = "#1a1a2e";
-		ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+		ctx.fillRect(0, 0, FIELD_WIDTH, FIELD_HEIGHT);
 
 		if (!gameState) {
 			// ゲーム状態がない場合は待機メッセージ
 			ctx.fillStyle = "#ffffff";
 			ctx.font = "24px Arial";
 			ctx.textAlign = "center";
-			ctx.fillText(
-				t("game.waitingForGame"),
-				CANVAS_WIDTH / 2,
-				CANVAS_HEIGHT / 2,
-			);
+			ctx.fillText(t("game.waitingForGame"), FIELD_WIDTH / 2, FIELD_HEIGHT / 2);
 			return;
 		}
 
@@ -174,8 +165,8 @@ export default function PongCanvas({
 		ctx.strokeStyle = "#4a4a6a";
 		ctx.lineWidth = 2;
 		ctx.beginPath();
-		ctx.moveTo(CANVAS_WIDTH / 2, 0);
-		ctx.lineTo(CANVAS_WIDTH / 2, CANVAS_HEIGHT);
+		ctx.moveTo(FIELD_WIDTH / 2, 0);
+		ctx.lineTo(FIELD_WIDTH / 2, FIELD_HEIGHT);
 		ctx.stroke();
 		ctx.setLineDash([]);
 
@@ -183,45 +174,27 @@ export default function PongCanvas({
 		ctx.fillStyle = "#ffffff";
 		ctx.font = "48px Arial";
 		ctx.textAlign = "center";
-		ctx.fillText(String(gameState.leftScore), CANVAS_WIDTH / 4, 60);
-		ctx.fillText(String(gameState.rightScore), (CANVAS_WIDTH * 3) / 4, 60);
+		ctx.fillText(String(gameState.leftScore), FIELD_WIDTH / 4, 60);
+		ctx.fillText(String(gameState.rightScore), (FIELD_WIDTH * 3) / 4, 60);
 
 		// 左パドル（isPlayer1 === true の時だけ緑、null/false は白）
 		ctx.fillStyle = isPlayer1 === true ? "#00ff88" : "#ffffff";
-		ctx.fillRect(
-			LEFT_PADDLE_X,
-			gameState.leftPaddleY,
-			PADDLE_WIDTH,
-			PADDLE_HEIGHT,
-		);
+		ctx.fillRect(LEFT_PADDLE_X, gameState.leftPaddleY, PAD_WIDTH, PAD_LENGTH);
 
 		// 右パドル（isPlayer1 === false の時だけ緑、null/true は白）
 		ctx.fillStyle = isPlayer1 === false ? "#00ff88" : "#ffffff";
-		ctx.fillRect(
-			RIGHT_PADDLE_X,
-			gameState.rightPaddleY,
-			PADDLE_WIDTH,
-			PADDLE_HEIGHT,
-		);
+		ctx.fillRect(RIGHT_PADDLE_X, gameState.rightPaddleY, PAD_WIDTH, PAD_LENGTH);
 
 		// ボール
 		ctx.fillStyle = "#ffff00";
 		ctx.beginPath();
 		ctx.arc(gameState.ball.x, gameState.ball.y, BALL_RADIUS, 0, Math.PI * 2);
 		ctx.fill();
-
-		// 自分のパドル位置を同期（確定後のみ）
-		if (isPlayer1 !== null) {
-			const myPaddleY = isPlayer1
-				? gameState.leftPaddleY
-				: gameState.rightPaddleY;
-			paddleYRef.current = myPaddleY;
-		}
 	}, [gameState, isPlayer1]);
 
 	// スケーリング後の表示サイズを計算
-	const displayWidth = CANVAS_WIDTH * scale;
-	const displayHeight = CANVAS_HEIGHT * scale;
+	const displayWidth = FIELD_WIDTH * scale;
+	const displayHeight = FIELD_HEIGHT * scale;
 
 	return (
 		<div
@@ -235,8 +208,8 @@ export default function PongCanvas({
 		>
 			<canvas
 				ref={canvasRef}
-				width={CANVAS_WIDTH}
-				height={CANVAS_HEIGHT}
+				width={FIELD_WIDTH}
+				height={FIELD_HEIGHT}
 				style={{
 					display: "block",
 					border: isFocused ? "2px solid #00ff88" : "2px solid #4a4a6a",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -108,7 +108,10 @@
 		"youLose": "YOU LOSE",
 		"backToOnline": "Back to Online",
 		"waitingForGame": "Waiting for game to start...",
-		"clickToStart": "Click to start controls"
+		"clickToStart": "Click to start controls",
+		"surrender": "Surrender",
+		"opponentDisconnected": "Opponent disconnected",
+		"waitingForReconnect": "Waiting for opponent to reconnect..."
 	},
 	"online": {
 		"status": "Status",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -108,7 +108,10 @@
 		"youLose": "DÉFAITE",
 		"backToOnline": "Retour en ligne",
 		"waitingForGame": "En attente du début de la partie...",
-		"clickToStart": "Cliquez pour commencer"
+		"clickToStart": "Cliquez pour commencer",
+		"surrender": "Abandonner",
+		"opponentDisconnected": "L'adversaire s'est déconnecté",
+		"waitingForReconnect": "En attente de la reconnexion de l'adversaire..."
 	},
 	"online": {
 		"status": "Statut",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -108,7 +108,10 @@
 		"youLose": "敗北",
 		"backToOnline": "オンラインに戻る",
 		"waitingForGame": "ゲーム開始を待っています...",
-		"clickToStart": "クリックして操作を開始"
+		"clickToStart": "クリックして操作を開始",
+		"surrender": "降参",
+		"opponentDisconnected": "相手が切断しました",
+		"waitingForReconnect": "相手の再接続を待っています..."
 	},
 	"online": {
 		"status": "ステータス",

--- a/frontend/src/services/gameSocket.ts
+++ b/frontend/src/services/gameSocket.ts
@@ -4,7 +4,7 @@
  */
 import { io, Socket } from "socket.io-client";
 import { SOCKET_URL, SOCKET_OPTIONS } from "./socketManager";
-import type { GameStateDto, PaddleMoveDto } from "/shared/game.interface";
+import type { GameStateDto } from "/shared/game.interface";
 
 // ゲーム用のSocket.IOクライアント（シングルトン）
 let gameSocket: Socket | null = null;
@@ -58,13 +58,46 @@ export const joinQueue = (): void => {
 };
 
 /**
- * パドルの位置を送信
- * @param y パドルのY座標（0〜500の範囲推奨）
+ * AI対戦を開始
  */
-export const movePaddle = (y: number): void => {
+export const joinAIGame = (): void => {
 	const socket = getGameSocket();
-	const payload: PaddleMoveDto = { y };
-	socket.emit("movePaddle", payload);
+	socket.emit("joinAIGame");
+	console.log("[GameSocket] AI対戦開始");
+};
+
+/**
+ * パドルを上に移動（サーバーがPAD_SPEED分移動を計算）
+ */
+export const moveUp = (): void => {
+	const socket = getGameSocket();
+	socket.emit("moveUp");
+};
+
+/**
+ * パドルを下に移動（サーバーがPAD_SPEED分移動を計算）
+ */
+export const moveDown = (): void => {
+	const socket = getGameSocket();
+	socket.emit("moveDown");
+};
+
+/**
+ * 試合中の再接続を試みる
+ */
+export const reconnectGame = (roomId: string): void => {
+	const socket = getGameSocket();
+	socket.emit("reconnectGame", { roomId });
+	console.log("[GameSocket] 再接続試行:", roomId);
+};
+
+/**
+ * 降参（試合を放棄）
+ */
+export const surrender = (): void => {
+	const socket = getGameSocket();
+	socket.emit("surrender");
+	console.log("[GameSocket] 降参");
 };
 
 // ============================================
@@ -81,22 +114,49 @@ export const onUpdateState = (callback: (dto: GameStateDto) => void): void => {
 
 /**
  * ゲーム終了を受信
+ * winner: 勝者のsocketId（AI勝利時はnull）
+ * reason: "disconnect" | "disconnectAI" | "surrender" | undefined（通常終了）
  */
 export const onGameOver = (
-	callback: (data: { winner: string }) => void,
+	callback: (data: {
+		winner: string | null;
+		roomId: string;
+		reason?: string;
+	}) => void,
 ): void => {
 	const socket = getGameSocket();
 	socket.on("gameOver", callback);
 };
 
 /**
- * マッチング成功を受信（ゲーム開始）
+ * 対戦相手が切断した通知
  */
-export const onMatchFound = (
-	callback: (data: { roomId: string; opponent: string }) => void,
+export const onPlayerDisconnected = (
+	callback: (data: { playerSocketId: string }) => void,
 ): void => {
 	const socket = getGameSocket();
-	socket.on("matchFound", callback);
+	socket.on("playerDisconnected", callback);
+};
+
+/**
+ * 対戦相手が再接続した通知
+ */
+export const onPlayerReconnected = (
+	callback: (data: { userId: number }) => void,
+): void => {
+	const socket = getGameSocket();
+	socket.on("playerReconnected", callback);
+};
+
+/**
+ * 再接続失敗の通知
+ * reason: "game_not_found" | "not_your_game" | "game_already_finished"
+ */
+export const onReconnectFailed = (
+	callback: (data: { reason: string }) => void,
+): void => {
+	const socket = getGameSocket();
+	socket.on("reconnectFailed", callback);
 };
 
 /**
@@ -107,4 +167,7 @@ export const removeAllGameListeners = (): void => {
 	socket.off("updateState");
 	socket.off("gameOver");
 	socket.off("matchFound");
+	socket.off("playerDisconnected");
+	socket.off("playerReconnected");
+	socket.off("reconnectFailed");
 };

--- a/frontend/src/services/gameSocket.ts
+++ b/frontend/src/services/gameSocket.ts
@@ -4,7 +4,7 @@
  */
 import { io, Socket } from "socket.io-client";
 import { SOCKET_URL, SOCKET_OPTIONS } from "./socketManager";
-import type { GameState, PaddleMoveDto } from "/shared/game.interface";
+import type { GameStateDto, PaddleMoveDto } from "/shared/game.interface";
 
 // ゲーム用のSocket.IOクライアント（シングルトン）
 let gameSocket: Socket | null = null;
@@ -74,7 +74,7 @@ export const movePaddle = (y: number): void => {
 /**
  * ゲーム状態更新を受信（1/60秒ごと）
  */
-export const onUpdateState = (callback: (state: GameState) => void): void => {
+export const onUpdateState = (callback: (dto: GameStateDto) => void): void => {
 	const socket = getGameSocket();
 	socket.on("updateState", callback);
 };

--- a/shared/game.constants.ts
+++ b/shared/game.constants.ts
@@ -5,6 +5,9 @@ export const PAD_SPEED = 8;
 export const PAD_WIDTH = 20;
 export const PAD_LENGTH = 100;
 export const PAD_BORDER_DIST = 40;
+export const AI_SOCKET_ID = null;
+export const AI_USER_ID = -1;
+export const GRACE_TIME = 15000;
 // 。。。finish
 
 export const FIELD_CENTER = { x: FIELD_WIDTH / 2, y: FIELD_HEIGHT / 2 };

--- a/shared/game.interface.ts
+++ b/shared/game.interface.ts
@@ -11,7 +11,7 @@ export interface Paddle {
 	width: number;
 }
 
-// ゲーム画面全体のリアルタイムな状態（1/60秒ごとに更新されるもの）
+// ゲーム画面全体のリアルタイムな状態（1/60秒ごとに更新されるもの
 export interface GameState {
 	ball: Point;
 	leftPaddleY: number;
@@ -21,7 +21,19 @@ export interface GameState {
 	isPaused: boolean;
 }
 
+// new way of emitting state:
+// the roomId will be used for reconnection attempts
+// これからback-endからGamestateじゃなくてこのGamestateDtoをFrontへ送ります
+// RoomIdをセーブしてreconnectしてみたい時にBackendに送ってくれれば、やりやすいと思います
+export interface GameStateDto {
+	roomId: string;
+	state: GameState;
+}
+
 // フロントエンドから送られてくる操作データ（パドルの移動指令）
+// old version
 export interface PaddleMoveDto {
 	y: number;
 }
+// NEW versions-> socket.emit("moveUp")
+// 新しい				-> socket.emit("moveDown")


### PR DESCRIPTION
このPRでは、前回のレビューでいただいたゲームに関する提案と、同僚が実装した新しい安全なユーザー認証方法に沿って作業しました。
主な変更点:
    • 関連する GameConstants を shared/ フォルダに移動し、バックエンドとフロントエンド間の整合性を保証。 
    • クライアントの識別はソケットIDではなく、新しいJWTを使用して取得されるユーザーIDで行うようになりました（ソケットIDは再接続時に変わるため）。 
    • バックエンドは単純な GameState を送信せず、GameStateDTO を送信するようになりました。このDTOには従来の GameState と、クライアントが属する roomId が含まれます。再接続時には roomId を使用してリクエストを送信します。 
    • パドル操作（moveUp / moveDown）は 入力ベース になりました。クライアントは入力イベントのみを送信し、サーバーがパドル位置を更新します。 
    • AI戦も同様のロジックで、パドルはサーバーが制御します。現状AIは非常にシンプルで、フロントエンドでレンダリングが実装され次第、テストしながら改善予定です。 
    • 自発的な棄権や一時的な切断・再接続の処理を追加しました。一時的に切断されたプレイヤーには再接続のための grace time を与えています。 
    • 再接続失敗時:
プレイヤーが試合に再接続しようとして失敗した場合、バックエンドはクライアントに reconnectFailed イベントを送信します。オブジェクトには失敗理由が含まれます。reason の値は以下の通りです: 
        ◦ "game_not_found" → 指定された roomId の試合は存在しない 
        ◦ "not_your_game" → 再接続を試みたプレイヤーはその試合の参加者ではない 
        ◦ "game_already_finished" → 試合はすでに終了している（例：グレースピリオドが終了した、またはプレイヤーが降参した） 
    • 降参/surrender:
プレイヤーが自発的に降参した場合、バックエンドは試合を停止し、両方のプレイヤーに gameOver イベントを送信します。内容は以下の通り: 
        ◦ winner → 勝者の socket ID 
        ◦ reason → "surrender" 
        ◦ roomId → 試合の ID
オンライン試合の場合、結果はデータベースにも保存されます。
フロントエンドへの影響:
    • 古い GameState の代わりに、新しい GameStateDTO を受け取るようにロジックを調整。 
    • 新しいバックエンドのエンドポイント: moveUp、moveDown、joinAIGame、reconnectGame、surrender 
        ◦ surrender → 自発的な棄権 
        ◦ reconnectGame → 一時的切断後の再接続 
        ◦ moveUp / moveDown は以前の movedTo（計算済みYを送信）を置き換え、パラメータ不要でバックエンドが自動的にプレイヤーと試合を特定 
