### PR TITLE
feat: M2 データベース設計 - ER図・マイグレーションファイル・エンティティテーブル名の統一

### DIFF
--- a/backend/src/chat/chat.entity.ts
+++ b/backend/src/chat/chat.entity.ts
@@ -7,7 +7,7 @@ import {
 } from "typeorm";
 import { ChatMessage } from "../../../shared/chat.interface";
 
-@Entity() // 「これはDBのテーブルですよ」というラベル
+@Entity("chat") // 「これはDBのテーブルですよ」というラベル
 export class Chat implements ChatMessage {
 	@PrimaryGeneratedColumn() // 自動で増えるID（1, 2, 3...）
 	id: number;

--- a/backend/src/game/match-history.entity.ts
+++ b/backend/src/game/match-history.entity.ts
@@ -5,7 +5,7 @@ import {
 	CreateDateColumn,
 } from "typeorm";
 
-@Entity()
+@Entity("match_history")
 export class MatchHistory {
 	@PrimaryGeneratedColumn()
 	id: number;

--- a/backend/src/migrations/20260323-InitialSchema.ts
+++ b/backend/src/migrations/20260323-InitialSchema.ts
@@ -1,0 +1,145 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// 初期マイグレーション: 全テーブルを作成する
+// 実行タイミング: データベースを初めてセットアップするとき
+//
+// 現在は database.config.ts の synchronize: true で自動同期しているため
+// 開発中はこのファイルを直接実行する必要はありません。
+// 本番環境では synchronize を false にして、このマイグレーションを使用してください。
+export class InitialSchema20260323 implements MigrationInterface {
+	name = "InitialSchema20260323";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		// =========================================================
+		// 1. users テーブル
+		// 認証情報・アカウント情報を管理する中心テーブル
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "users" (
+                "id"                SERIAL PRIMARY KEY,
+                "username"          VARCHAR NOT NULL,
+                "password"          VARCHAR,
+                "forty_two_id"      VARCHAR,
+                "is_2fa_enabled"    BOOLEAN NOT NULL DEFAULT false,
+                "two_factor_secret" VARCHAR,
+                "created_at"        TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "UQ_users_username"      UNIQUE ("username"),
+                CONSTRAINT "UQ_users_forty_two_id"  UNIQUE ("forty_two_id")
+            )
+        `);
+
+		// =========================================================
+		// 2. profiles テーブル
+		// users と 1対1 のプロフィール情報
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "profiles" (
+                "id"            SERIAL PRIMARY KEY,
+                "user_id"       INTEGER NOT NULL,
+                "displayName"   VARCHAR(50),
+                "bio"           TEXT,
+                "avatarUrl"     VARCHAR,
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                "updatedAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "FK_profiles_user_id"
+                    FOREIGN KEY ("user_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE
+            )
+        `);
+
+		// =========================================================
+		// 3. friends テーブル
+		// 承認済みフレンド関係。(user_id, friend_id) はユニーク
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "friends" (
+                "id"            SERIAL PRIMARY KEY,
+                "user_id"       INTEGER NOT NULL,
+                "friend_id"     INTEGER NOT NULL,
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "FK_friends_user_id"
+                    FOREIGN KEY ("user_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE,
+                CONSTRAINT "FK_friends_friend_id"
+                    FOREIGN KEY ("friend_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE,
+                CONSTRAINT "UQ_friends_user_friend"
+                    UNIQUE ("user_id", "friend_id")
+            )
+        `);
+
+		// =========================================================
+		// 4. friend_requests テーブル
+		// フレンド申請中のレコード。status enum で状態を管理
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TYPE "friend_request_status_enum"
+                AS ENUM ('pending', 'accepted', 'rejected')
+        `);
+
+		await queryRunner.query(`
+            CREATE TABLE "friend_requests" (
+                "id"            SERIAL PRIMARY KEY,
+                "sender_id"     INTEGER NOT NULL,
+                "receiver_id"   INTEGER NOT NULL,
+                "status"        "friend_request_status_enum" NOT NULL DEFAULT 'pending',
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                "updatedAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "FK_friend_requests_sender_id"
+                    FOREIGN KEY ("sender_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE,
+                CONSTRAINT "FK_friend_requests_receiver_id"
+                    FOREIGN KEY ("receiver_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE
+            )
+        `);
+
+		// =========================================================
+		// 5. chat テーブル
+		// チャットメッセージの履歴
+		// sender は username の文字列（FK なし）
+		// → ユーザー削除後もメッセージ履歴を保持するため
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "chat" (
+                "id"        SERIAL PRIMARY KEY,
+                "sender"    VARCHAR NOT NULL,
+                "content"   TEXT NOT NULL,
+                "roomId"    VARCHAR NOT NULL,
+                "createdAt" TIMESTAMP NOT NULL DEFAULT now()
+            )
+        `);
+
+		// =========================================================
+		// 6. match_history テーブル
+		// 対戦履歴。winnerUserId/loserUserId は nullable
+		// → アカウント削除時に NULL に匿名化するため（FK制約なし）
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "match_history" (
+                "id"            SERIAL PRIMARY KEY,
+                "winnerUserId"  INTEGER,
+                "loserUserId"   INTEGER,
+                "winnerScore"   INTEGER NOT NULL,
+                "loserScore"    INTEGER NOT NULL,
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now()
+            )
+        `);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		// 作成と逆順に削除する（外部キー制約の依存関係を考慮）
+		await queryRunner.query(`DROP TABLE IF EXISTS "match_history"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "chat"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "friend_requests"`);
+		await queryRunner.query(`DROP TYPE IF EXISTS "friend_request_status_enum"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "friends"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "profiles"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "users"`);
+	}
+}

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -1,0 +1,96 @@
+# ER図（ft_transcendence データベース設計）
+
+## テーブル一覧
+
+| テーブル名        | 対応 Entity     | 説明                              |
+| ----------------- | --------------- | --------------------------------- |
+| `users`           | `User`          | 認証情報・アカウント              |
+| `profiles`        | `Profile`       | プロフィール情報（users と 1対1） |
+| `friends`         | `Friend`        | フレンド関係（承認済み）          |
+| `friend_requests` | `FriendRequest` | フレンドリクエスト（申請中）      |
+| `chat`            | `Chat`          | チャットメッセージ                |
+| `match_history`   | `MatchHistory`  | 対戦履歴                          |
+
+## ER図
+
+```mermaid
+erDiagram
+    users {
+        int id PK "自動採番"
+        varchar username UK "ユーザー名（一意）"
+        varchar password "パスワードハッシュ（42OAuthは null）"
+        varchar forty_two_id UK "42のユーザーID（オプション）"
+        boolean is_2fa_enabled "2FA有効フラグ（default: false）"
+        varchar two_factor_secret "2FAシークレット（nullable）"
+        timestamp created_at "作成日時（自動）"
+    }
+
+    profiles {
+        int id PK "自動採番"
+        int user_id FK "users.id への外部キー"
+        varchar displayName "表示名（最大50文字、nullable）"
+        text bio "自己紹介（nullable）"
+        varchar avatarUrl "アバター画像URL（nullable）"
+        timestamp createdAt "作成日時（自動）"
+        timestamp updatedAt "更新日時（自動）"
+    }
+
+    friends {
+        int id PK "自動採番"
+        int user_id FK "users.id への外部キー"
+        int friend_id FK "users.id への外部キー"
+        timestamp createdAt "フレンド成立日時（自動）"
+    }
+
+    friend_requests {
+        int id PK "自動採番"
+        int sender_id FK "users.id（送信者）"
+        int receiver_id FK "users.id（受信者）"
+        enum status "pending / accepted / rejected"
+        timestamp createdAt "リクエスト送信日時（自動）"
+        timestamp updatedAt "更新日時（自動）"
+    }
+
+    chat {
+        int id PK "自動採番"
+        varchar sender "送信者のユーザー名"
+        text content "メッセージ本文"
+        varchar roomId "チャットルームID"
+        timestamp createdAt "送信日時（自動）"
+    }
+
+    match_history {
+        int id PK "自動採番"
+        int winnerUserId "勝者の users.id（nullable: 匿名化対応）"
+        int loserUserId "敗者の users.id（nullable: 匿名化対応）"
+        int winnerScore "勝者のスコア"
+        int loserScore "敗者のスコア"
+        timestamp createdAt "対戦日時（自動）"
+    }
+
+    users ||--|| profiles : "1対1（user_id → users.id）"
+    users ||--o{ friends : "user_id（フレンドの一方）"
+    users ||--o{ friends : "friend_id（フレンドの他方）"
+    users ||--o{ friend_requests : "sender_id（送信者）"
+    users ||--o{ friend_requests : "receiver_id（受信者）"
+```
+
+## リレーション説明
+
+| リレーション                | 種類           | 説明                                                                                                                     |
+| --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `users` ↔ `profiles`        | 1対1           | 1ユーザーに1プロフィール。ユーザー削除時にCASCADE                                                                        |
+| `users` ↔ `friends`         | 1対多（2経路） | `user_id` と `friend_id` の両方が `users` を参照。`(user_id, friend_id)` のペアはUNIQUE制約あり                          |
+| `users` ↔ `friend_requests` | 1対多（2経路） | `sender_id`（送信者）と `receiver_id`（受信者）が `users` を参照                                                         |
+| `chat`                      | 独立           | `sender` は `users.username` を文字列で保持（FK なし）。ユーザー削除時も履歴を保持                                       |
+| `match_history`             | 独立（疑似FK） | `winnerUserId`/`loserUserId` は `users.id` を参照するが、FK制約なし。削除済みユーザーの試合履歴を保持するため `nullable` |
+
+## 制約一覧
+
+| テーブル          | 制約           | 対象列                                      |
+| ----------------- | -------------- | ------------------------------------------- |
+| `users`           | UNIQUE         | `username`                                  |
+| `users`           | UNIQUE         | `forty_two_id`                              |
+| `profiles`        | UNIQUE（暗黙） | `user_id`（OneToOneのため）                 |
+| `friends`         | UNIQUE         | `(user_id, friend_id)`                      |
+| `friend_requests` | ENUM           | `status`: `pending`, `accepted`, `rejected` |


### PR DESCRIPTION
## 概要

マイルストーン2（データベース設計）の成果物を追加するPR。

## 変更内容

### 新規追加
- `docs/er-diagram.md` — 全6テーブルのER図（Mermaid記法）
  - テーブル定義・リレーション・制約一覧を記載
- `backend/src/migrations/20260323-InitialSchema.ts` — TypeORM初期マイグレーション
  - 全テーブルの `CREATE TABLE`（up）と `DROP TABLE`（down）を実装

### 修正
- `backend/src/chat/chat.entity.ts`: `@Entity()` → `@Entity("chat")`
- `backend/src/game/match-history.entity.ts`: `@Entity()` → `@Entity("match_history")`
  - 他のエンティティ（users, profiles, friends, friend_requests）はすでに明示済みだったため統一

## DB設計の概要

```
users（中心テーブル）
  ├── profiles       1対1（CASCADE）
  ├── friends        1対多（user_id / friend_id の2経路）
  └── friend_requests 1対多（sender_id / receiver_id の2経路）

chat         独立（sender は FK なし、削除ユーザーの履歴保持のため）
match_history 独立（winnerUserId / loserUserId は nullable、GDPR匿名化対応）
```

## レビュー時の注意

- `migrations/` は現在 `synchronize: true` で開発中のため直接実行不要
- 本番切り替え時は `database.config.ts` の `migrationsRun: true` で自動適用する予定
- 他ブランチ（m11, security-update 等）にも `@Entity()` の修正が必要。マージ時に競合する場合はこのブランチ側を採用すること

## このPRに含まれる差分について

このブランチは `feature/m7-gdpr-user-stats` から派生しているため、`git diff main` には M2以前のマイルストーン変更も含まれる。M2固有のコミットは以下の2つ。

| コミット | 内容 |
|---|---|
| `a3415c5` | ER図・マイグレーションファイルを追加 |
| `ae1b03c` | ChatとMatchHistoryエンティティにテーブル名を明示 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)