### PR TITLE
fix: コンソールエラーを解消（4xx→200返却への変更）

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -151,10 +151,10 @@ export class AuthController {
 	): Promise<LoginResponse> {
 		const user = await this.authService.login(body.username, body.password);
 		if (!user) {
-			throw new HttpException(
-				"ユーザー名またはパスワードが間違っています",
-				HttpStatus.UNAUTHORIZED,
-			);
+			return {
+				success: false,
+				message: "ユーザー名またはパスワードが間違っています",
+			};
 		}
 
 		// 2FAが有効なユーザーは一時トークンを発行してコード入力画面へ

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -39,11 +39,22 @@ interface FortyTwoCallbackRequest extends Request {
 
 // JWTをCookieにセットするヘルパー関数
 function setJwtCookie(res: Response, token: string) {
+	const isSecure = process.env.NODE_ENV !== "development";
+	const maxAge = 24 * 60 * 60 * 1000; // 24時間
+
 	res.cookie("access_token", token, {
 		httpOnly: true, // JS から読めない（XSS対策）
 		sameSite: "strict", // 他サイトからのリクエストでは Cookie を送らない（CSRF対策）
-		secure: process.env.NODE_ENV !== "development", // 本番は HTTPS のみ
-		maxAge: 24 * 60 * 60 * 1000, // 24時間
+		secure: isSecure, // 本番は HTTPS のみ
+		maxAge,
+	});
+
+	// フロントエンドがログイン状態を判定するための補助cookie（httpOnly: false）
+	res.cookie("logged_in", "true", {
+		httpOnly: false,
+		sameSite: "strict",
+		secure: isSecure,
+		maxAge,
 	});
 }
 
@@ -287,6 +298,7 @@ export class AuthController {
 		@Res({ passthrough: true }) res: Response,
 	): Promise<LogoutResponse> {
 		res.clearCookie("access_token");
+		res.clearCookie("logged_in");
 		res.clearCookie("temp_token");
 		return { success: true, message: "ログアウト成功" };
 	}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -197,26 +197,20 @@ export class AuthController {
 	) {
 		const tempToken = req.cookies?.temp_token;
 		if (!tempToken) {
-			throw new HttpException(
-				"セッションが無効です。再度ログインしてください",
-				HttpStatus.UNAUTHORIZED,
-			);
+			return {
+				success: false,
+				message: "セッションが無効です。再度ログインしてください",
+			};
 		}
 
 		const payload = this.authService.verifyTempToken(tempToken);
 		if (!payload) {
-			throw new HttpException(
-				"セッションが期限切れです",
-				HttpStatus.UNAUTHORIZED,
-			);
+			return { success: false, message: "セッションが期限切れです" };
 		}
 
 		const user = await this.authService.findById(payload.sub);
 		if (!user || !user.two_factor_secret) {
-			throw new HttpException(
-				"ユーザーが見つかりません",
-				HttpStatus.UNAUTHORIZED,
-			);
+			return { success: false, message: "ユーザーが見つかりません" };
 		}
 
 		const isValid = this.twoFactorService.verifyToken(
@@ -224,10 +218,7 @@ export class AuthController {
 			body.token,
 		);
 		if (!isValid) {
-			throw new HttpException(
-				"コードが正しくありません",
-				HttpStatus.UNAUTHORIZED,
-			);
+			return { success: false, message: "コードが正しくありません" };
 		}
 
 		// 検証OK → 本物のJWTを発行
@@ -263,10 +254,7 @@ export class AuthController {
 			body.token,
 		);
 		if (!success) {
-			throw new HttpException(
-				"コードが正しくありません",
-				HttpStatus.BAD_REQUEST,
-			);
+			return { success: false, message: "コードが正しくありません" };
 		}
 
 		return { success: true, message: "2FAを有効化しました" };

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -139,7 +139,10 @@ export class AuthController {
 				user: { id: user.id, username: user.username },
 			};
 		} catch (error) {
-			throw new HttpException((error as Error).message, HttpStatus.BAD_REQUEST);
+			return {
+				success: false,
+				message: (error as Error).message,
+			};
 		}
 	}
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -234,7 +234,7 @@ export class AuthController {
 	async setupTwoFactor(@Req() req: AuthenticatedRequest) {
 		const fullUser = await this.authService.findById(req.user.id);
 		if (!fullUser)
-			throw new HttpException("ユーザーが見つかりません", HttpStatus.NOT_FOUND);
+			return { success: false, message: "ユーザーが見つかりません" };
 
 		return this.twoFactorService.generateSecret(fullUser);
 	}
@@ -247,7 +247,7 @@ export class AuthController {
 	) {
 		const fullUser = await this.authService.findById(req.user.id);
 		if (!fullUser)
-			throw new HttpException("ユーザーが見つかりません", HttpStatus.NOT_FOUND);
+			return { success: false, message: "ユーザーが見つかりません" };
 
 		const success = await this.twoFactorService.enableTwoFactor(
 			fullUser,
@@ -265,7 +265,7 @@ export class AuthController {
 	async disableTwoFactor(@Req() req: AuthenticatedRequest) {
 		const fullUser = await this.authService.findById(req.user.id);
 		if (!fullUser)
-			throw new HttpException("ユーザーが見つかりません", HttpStatus.NOT_FOUND);
+			return { success: false, message: "ユーザーが見つかりません" };
 
 		await this.twoFactorService.disableTwoFactor(fullUser);
 		return { success: true, message: "2FAを無効化しました" };

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -6,7 +6,6 @@ import {
 	Body,
 	Param,
 	Req,
-	BadRequestException,
 } from "@nestjs/common";
 import { Request } from "express";
 import { FriendService } from "./friend.service";
@@ -39,25 +38,31 @@ export class FriendController {
 
 		const receiverIdOrUsername = body.receiverId || body.username;
 		if (!receiverIdOrUsername) {
-			throw new BadRequestException("receiverId または username が必要です");
+			return {
+				success: false,
+				message: "receiverId または username が必要です",
+			};
 		}
 
-		const request = await this.friendService.sendFriendRequest(
-			user.id,
-			receiverIdOrUsername,
-		);
-
-		return {
-			success: true,
-			message: "フレンドリクエストを送信しました",
-			friendRequest: {
-				id: request.id,
-				senderId: request.senderId,
-				receiverId: request.receiverId,
-				status: request.status,
-				createdAt: request.createdAt.toISOString(),
-			},
-		};
+		try {
+			const request = await this.friendService.sendFriendRequest(
+				user.id,
+				receiverIdOrUsername,
+			);
+			return {
+				success: true,
+				message: "フレンドリクエストを送信しました",
+				friendRequest: {
+					id: request.id,
+					senderId: request.senderId,
+					receiverId: request.receiverId,
+					status: request.status,
+					createdAt: request.createdAt.toISOString(),
+				},
+			};
+		} catch (error) {
+			return { success: false, message: (error as Error).message };
+		}
 	}
 
 	// POST /friends/accept/:requestId - フレンドリクエスト承認
@@ -70,12 +75,15 @@ export class FriendController {
 
 		const id = parseInt(requestId, 10);
 		if (isNaN(id)) {
-			throw new BadRequestException("無効なリクエストIDです");
+			return { success: false, message: "無効なリクエストIDです" };
 		}
 
-		await this.friendService.acceptFriendRequest(id, user.id);
-
-		return { success: true, message: "フレンドリクエストを承認しました" };
+		try {
+			await this.friendService.acceptFriendRequest(id, user.id);
+			return { success: true, message: "フレンドリクエストを承認しました" };
+		} catch (error) {
+			return { success: false, message: (error as Error).message };
+		}
 	}
 
 	// POST /friends/reject/:requestId - フレンドリクエスト拒否
@@ -88,12 +96,15 @@ export class FriendController {
 
 		const id = parseInt(requestId, 10);
 		if (isNaN(id)) {
-			throw new BadRequestException("無効なリクエストIDです");
+			return { success: false, message: "無効なリクエストIDです" };
 		}
 
-		await this.friendService.rejectFriendRequest(id, user.id);
-
-		return { success: true, message: "フレンドリクエストを拒否しました" };
+		try {
+			await this.friendService.rejectFriendRequest(id, user.id);
+			return { success: true, message: "フレンドリクエストを拒否しました" };
+		} catch (error) {
+			return { success: false, message: (error as Error).message };
+		}
 	}
 
 	// DELETE /friends/:friendId - フレンド削除
@@ -106,12 +117,15 @@ export class FriendController {
 
 		const id = parseInt(friendId, 10);
 		if (isNaN(id)) {
-			throw new BadRequestException("無効なユーザーIDです");
+			return { success: false, message: "無効なユーザーIDです" };
 		}
 
-		await this.friendService.removeFriend(user.id, id);
-
-		return { success: true, message: "フレンドを削除しました" };
+		try {
+			await this.friendService.removeFriend(user.id, id);
+			return { success: true, message: "フレンドを削除しました" };
+		} catch (error) {
+			return { success: false, message: (error as Error).message };
+		}
 	}
 
 	// GET /friends - フレンドリスト取得
@@ -142,7 +156,7 @@ export class FriendController {
 
 		const targetUserId = parseInt(userId, 10);
 		if (isNaN(targetUserId)) {
-			throw new BadRequestException("無効なユーザーIDです");
+			return { isFriend: false };
 		}
 
 		return this.friendService.getFriendStatus(user.id, targetUserId);

--- a/backend/src/profile/profile.controller.ts
+++ b/backend/src/profile/profile.controller.ts
@@ -13,7 +13,6 @@ import {
 import { FileInterceptor } from "@nestjs/platform-express";
 import { diskStorage } from "multer";
 import { extname } from "path";
-import { unlink } from "fs";
 import { Request } from "express";
 import { ProfileService } from "./profile.service";
 
@@ -97,6 +96,14 @@ export class ProfileController {
 					callback(null, `user-${userId}-${timestamp}${ext}`);
 				},
 			}),
+			fileFilter: (req, file, callback) => {
+				// throwせずfalseを返すことで、不正ファイルを保存前に拒否（コンソールエラーなし）
+				if (!file.mimetype.match(/\/(jpg|jpeg|png|gif)$/)) {
+					callback(null, false);
+				} else {
+					callback(null, true);
+				}
+			},
 			limits: { fileSize: 5 * 1024 * 1024 },
 		}),
 	)
@@ -107,19 +114,10 @@ export class ProfileController {
 		const user = req.user;
 
 		if (!file) {
+			// fileFilterで拒否された場合（画像以外）もここに来る
 			return {
 				success: false,
-				message: "ファイルがアップロードされていません",
-			};
-		}
-
-		// ファイル形式チェック（multer保存後にコントローラ内で検証）
-		if (!file.mimetype.match(/\/(jpg|jpeg|png|gif)$/)) {
-			// 不正なファイルを削除してからエラーを返す
-			unlink(`./uploads/avatars/${file.filename}`, () => {});
-			return {
-				success: false,
-				message: "画像ファイルのみアップロード可能です",
+				message: "画像ファイルのみアップロード可能です（jpg/jpeg/png/gif）",
 			};
 		}
 

--- a/backend/src/profile/profile.controller.ts
+++ b/backend/src/profile/profile.controller.ts
@@ -49,13 +49,19 @@ export class ProfileController {
 
 	// GET /profile/:id - 他のユーザーのプロフィール取得
 	@Get(":id")
-	async getProfile(@Param("id") id: string): Promise<GetProfileResponse> {
+	async getProfile(
+		@Param("id") id: string,
+	): Promise<GetProfileResponse | { success: false; message: string }> {
 		const userId = parseInt(id, 10);
 		if (isNaN(userId)) {
-			throw new Error("無効なユーザーIDです");
+			return { success: false, message: "無効なユーザーIDです" };
 		}
 
-		return this.profileService.getProfileByUserId(userId);
+		try {
+			return await this.profileService.getProfileByUserId(userId);
+		} catch (error) {
+			return { success: false, message: (error as Error).message };
+		}
 	}
 
 	// PUT /profile/me - プロフィール更新

--- a/backend/src/profile/profile.controller.ts
+++ b/backend/src/profile/profile.controller.ts
@@ -9,11 +9,11 @@ import {
 	Req,
 	UseInterceptors,
 	UploadedFile,
-	BadRequestException,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { diskStorage } from "multer";
 import { extname } from "path";
+import { unlink } from "fs";
 import { Request } from "express";
 import { ProfileService } from "./profile.service";
 
@@ -52,7 +52,7 @@ export class ProfileController {
 	async getProfile(@Param("id") id: string): Promise<GetProfileResponse> {
 		const userId = parseInt(id, 10);
 		if (isNaN(userId)) {
-			throw new BadRequestException("無効なユーザーIDです");
+			throw new Error("無効なユーザーIDです");
 		}
 
 		return this.profileService.getProfileByUserId(userId);
@@ -91,15 +91,6 @@ export class ProfileController {
 					callback(null, `user-${userId}-${timestamp}${ext}`);
 				},
 			}),
-			fileFilter: (req, file, callback) => {
-				if (!file.mimetype.match(/\/(jpg|jpeg|png|gif)$/)) {
-					return callback(
-						new BadRequestException("画像ファイルのみアップロード可能です"),
-						false,
-					);
-				}
-				callback(null, true);
-			},
 			limits: { fileSize: 5 * 1024 * 1024 },
 		}),
 	)
@@ -110,7 +101,20 @@ export class ProfileController {
 		const user = req.user;
 
 		if (!file) {
-			throw new BadRequestException("ファイルがアップロードされていません");
+			return {
+				success: false,
+				message: "ファイルがアップロードされていません",
+			};
+		}
+
+		// ファイル形式チェック（multer保存後にコントローラ内で検証）
+		if (!file.mimetype.match(/\/(jpg|jpeg|png|gif)$/)) {
+			// 不正なファイルを削除してからエラーを返す
+			unlink(`./uploads/avatars/${file.filename}`, () => {});
+			return {
+				success: false,
+				message: "画像ファイルのみアップロード可能です",
+			};
 		}
 
 		const avatarUrl = `/uploads/avatars/${file.filename}`;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -121,6 +121,11 @@ function App() {
 		e.preventDefault();
 		try {
 			const data = await login(username, password);
+			if (!data.success) {
+				// ログイン失敗（200レスポンスで返却される）
+				setMessage(data.message || "auth.loginFailed");
+				return;
+			}
 			if (data.message === "2FA_REQUIRED") {
 				// 2FA有効ユーザー → コード入力画面へ
 				setNeeds2FA(true);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,7 +105,12 @@ function App() {
 	const handleRegister = async (e: React.FormEvent) => {
 		e.preventDefault();
 		try {
-			await register(username, password);
+			const data = await register(username, password);
+			if (!data.success) {
+				// 登録失敗（200レスポンスで返却される）
+				setMessage(data.message || "auth.registerFailed");
+				return;
+			}
 			setMessage("auth.registerSuccess");
 			setIsLogin(true);
 			setUsername("");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -87,8 +87,12 @@ function App() {
 		checkLoginStatus();
 	}, []);
 
-	// ログイン状態確認
+	// ログイン状態確認（logged_in cookieがない場合はAPIコールをスキップ）
 	const checkLoginStatus = async () => {
+		if (!document.cookie.includes("logged_in")) {
+			setUser(null);
+			return;
+		}
 		try {
 			const userData = await getCurrentUser();
 			setUser(userData);

--- a/frontend/src/components/TwoFAVerify.tsx
+++ b/frontend/src/components/TwoFAVerify.tsx
@@ -21,12 +21,7 @@ function TwoFAVerify({ onVerified, onCancel }: TwoFAVerifyProps) {
 		setLoading(true);
 		setMessage("");
 		try {
-			const data = await verify2FA(token);
-			if (!data.success) {
-				// 認証失敗（200レスポンスで返却される）
-				setMessage(data.message || "twofa.verifyFailed");
-				return;
-			}
+			await verify2FA(token);
 			const userData = await getCurrentUser();
 			onVerified(userData);
 		} catch (err) {

--- a/frontend/src/components/TwoFAVerify.tsx
+++ b/frontend/src/components/TwoFAVerify.tsx
@@ -21,7 +21,11 @@ function TwoFAVerify({ onVerified, onCancel }: TwoFAVerifyProps) {
 		setLoading(true);
 		setMessage("");
 		try {
-			await verify2FA(token);
+			const data = await verify2FA(token);
+			if (!data.success) {
+				setMessage(data.message || "twofa.verifyFailed");
+				return;
+			}
 			const userData = await getCurrentUser();
 			onVerified(userData);
 		} catch (err) {

--- a/frontend/src/components/TwoFAVerify.tsx
+++ b/frontend/src/components/TwoFAVerify.tsx
@@ -21,7 +21,12 @@ function TwoFAVerify({ onVerified, onCancel }: TwoFAVerifyProps) {
 		setLoading(true);
 		setMessage("");
 		try {
-			await verify2FA(token);
+			const data = await verify2FA(token);
+			if (!data.success) {
+				// 認証失敗（200レスポンスで返却される）
+				setMessage(data.message || "twofa.verifyFailed");
+				return;
+			}
 			const userData = await getCurrentUser();
 			onVerified(userData);
 		} catch (err) {

--- a/shared/friend.types.ts
+++ b/shared/friend.types.ts
@@ -51,7 +51,7 @@ export interface SendFriendRequestRequest {
 export interface SendFriendRequestResponse {
 	success: boolean;
 	message: string;
-	friendRequest: {
+	friendRequest?: {
 		id: number;
 		senderId: number;
 		receiverId: number;

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -62,7 +62,7 @@ export interface RegisterRequest {
 export interface RegisterResponse {
 	success: boolean;
 	message: string;
-	user: GetMeResponse; // API定義を統一
+	user?: GetMeResponse; // 登録失敗時はundefined
 }
 
 // POST /auth/login

--- a/shared/profile.types.ts
+++ b/shared/profile.types.ts
@@ -50,7 +50,7 @@ export interface UpdateProfileResponse {
 export interface UploadAvatarResponse {
 	success: boolean;
 	message: string;
-	avatarUrl: string; // アップロードされた画像のURL
+	avatarUrl?: string; // アップロードされた画像のURL（失敗時はundefined）
 }
 
 // DELETE /profile/avatar - アバター削除


### PR DESCRIPTION
## 概要

ブラウザコンソールに以下のエラーが出ていた問題を修正しました。

- パスワード間違い時のログイン失敗 → 401
- 登録済みユーザーの再登録 → 400
- 初回ページ起動時の未ログイン状態での `/auth/me` → 401
- 2FA認証失敗・セッション無効 → 401/400
- フレンドリクエスト系エラー → 400/404/409
- アバターアップロード失敗 → 400
- `GET /profile/:id` の無効ID・未検出 → 400/404/500

## 対応方針

アプリケーションレベルのエラーは 4xx を返さず、**HTTP 200 + `{ success: false, message: "..." }`** で返すように統一。

## 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `backend/src/auth/auth.controller.ts` | バックエンド | ログイン失敗・2FA系エラーを200返却に変更 |
| `backend/src/friend/friend.controller.ts` | バックエンド | フレンド系エラーを200返却に変更 |
| `backend/src/profile/profile.controller.ts` | バックエンド | アバター・プロフィール系エラーを200返却に変更 |
| `frontend/src/App.tsx` | フロントエンド | `logged_in` Cookie確認で `/auth/me` 呼び出しをスキップ、`success:false` 時の処理追加 |
| `shared/index.ts` | 共有型 | `RegisterResponse.user` を optional に変更 |
| `shared/friend.types.ts` | 共有型 | `friendRequest` を optional に変更 |
| `shared/profile.types.ts` | 共有型 | `avatarUrl` を optional に変更 |

## テスト観点

- [ ] 初回ページ起動時にコンソールエラーが出ないこと
- [ ] パスワード間違いでログイン失敗時にコンソールエラーが出ないこと
- [ ] 登録済みユーザーの再登録時にコンソールエラーが出ないこと
- [ ] 2FAコード間違い時にコンソールエラーが出ないこと
- [ ] フレンドリクエスト操作（重複・権限なし等）でコンソールエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)