### PR TITLE
feat: ゲーム中のモード切替確認とAI再戦機能を追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,6 @@
 		"": {
 			"name": "transcendence-frontend",
 			"version": "1.0.0",
-			"hasInstallScript": true,
 			"dependencies": {
 				"@alexium216/react-pong": "^1.1.3",
 				"axios": "^1.4.0",
@@ -1337,14 +1336,14 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.13.6",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
 				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
@@ -2006,10 +2005,13 @@
 			}
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/react": {
 			"version": "18.3.1",
@@ -2252,9 +2254,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,6 +67,9 @@ function App() {
 	// Mobile menu
 	const [menuOpen, setMenuOpen] = useState(false);
 
+	// AIモード再マウント用キー
+	const [aiGameKey, setAiGameKey] = useState(() => Date.now());
+
 	// ゲーム中のモード切り替え確認
 	const [pendingNavigation, setPendingNavigation] = useState<Page | null>(null);
 
@@ -244,10 +247,11 @@ function App() {
 				// GamePage 側で props を受け取れるようにしておく（UI表示のため）
 				return (
 					<GamePage
+						key={aiGameKey}
 						mode="ai"
 						roomId={gameRoomId ?? undefined}
 						opponent={gameOpponent}
-						onBack={() => setCurrentPage("home")}
+						onBack={() => setAiGameKey(Date.now())}
 					/>
 				);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,8 @@ import ChatPage from "./components/ChatPage";
 import LegalModal, { LegalType } from "./components/LegalModal";
 import StatsDashboard from "./components/StatsDashboard";
 import GdprSettings from "./components/GdprSettings";
+import ConfirmDialog from "./components/ConfirmDialog";
+import { surrender } from "./services/gameSocket";
 import "./App.css";
 import "./styles/responsive.css";
 
@@ -65,9 +67,38 @@ function App() {
 	// Mobile menu
 	const [menuOpen, setMenuOpen] = useState(false);
 
+	// ゲーム中のモード切り替え確認
+	const [pendingNavigation, setPendingNavigation] = useState<Page | null>(null);
+
 	const navigateTo = (page: Page) => {
 		setCurrentPage(page);
 		setMenuOpen(false);
+	};
+
+	// ゲーム画面にいるかどうか（SSOT: 既存ステートから導出）
+	const isInGamePage =
+		currentPage === "game" || (currentPage === "online" && gameRoomId !== null);
+
+	// ゲーム中なら確認ポップアップ、そうでなければ即遷移
+	const handleNavigation = (target: Page, resetGame = false) => {
+		if (isInGamePage && target !== currentPage) {
+			setPendingNavigation(target);
+			return;
+		}
+		if (resetGame) {
+			setGameRoomId(null);
+			setGameOpponent(null);
+		}
+		navigateTo(target);
+	};
+
+	// ポップアップ承諾: surrender → 遷移（同一ソケットを再利用し順序保証）
+	const handleConfirmLeave = () => {
+		surrender();
+		setGameRoomId(null);
+		setGameOpponent(null);
+		if (pendingNavigation) navigateTo(pendingNavigation);
+		setPendingNavigation(null);
 	};
 
 	// DM context（FriendList → ChatPage 連携用）
@@ -323,11 +354,7 @@ function App() {
 								<li>
 									<button
 										className={currentPage === "online" ? "active" : ""}
-										onClick={() => {
-											setGameRoomId(null);
-											setGameOpponent(null);
-											navigateTo("online");
-										}}
+										onClick={() => handleNavigation("online", true)}
 									>
 										{t("nav.online")}
 									</button>
@@ -336,11 +363,7 @@ function App() {
 								<li>
 									<button
 										className={currentPage === "game" ? "active" : ""}
-										onClick={() => {
-											setGameRoomId(null);
-											setGameOpponent(null);
-											navigateTo("game");
-										}}
+										onClick={() => handleNavigation("game", true)}
 									>
 										{t("nav.ai")}
 									</button>
@@ -539,6 +562,16 @@ function App() {
 			</div>
 			{legalModal && (
 				<LegalModal type={legalModal} onClose={() => setLegalModal(null)} />
+			)}
+			{pendingNavigation !== null && (
+				<ConfirmDialog
+					title={t("game.switchConfirmTitle")}
+					message={t("game.switchConfirmMessage")}
+					confirmLabel={t("game.switchConfirmOk")}
+					cancelLabel={t("game.switchConfirmCancel")}
+					onConfirm={handleConfirmLeave}
+					onCancel={() => setPendingNavigation(null)}
+				/>
 			)}
 		</div>
 	);

--- a/frontend/src/components/ConfirmDialog.module.css
+++ b/frontend/src/components/ConfirmDialog.module.css
@@ -1,0 +1,68 @@
+.overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+	padding: 16px;
+}
+
+.dialog {
+	background: white;
+	border-radius: 12px;
+	padding: 24px;
+	max-width: 420px;
+	width: 100%;
+	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.title {
+	font-size: 1.1rem;
+	font-weight: 700;
+	color: #333;
+	margin: 0 0 12px;
+}
+
+.message {
+	font-size: 0.875rem;
+	color: #666;
+	line-height: 1.6;
+	margin: 0 0 20px;
+}
+
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+}
+
+.btnCancel {
+	padding: 8px 16px;
+	border: 1px solid #ddd;
+	border-radius: 8px;
+	background: white;
+	color: #333;
+	cursor: pointer;
+	font-size: 0.875rem;
+}
+
+.btnCancel:hover {
+	background: #f5f5f5;
+}
+
+.btnConfirm {
+	padding: 8px 16px;
+	border: none;
+	border-radius: 8px;
+	background: #e74c3c;
+	color: white;
+	cursor: pointer;
+	font-size: 0.875rem;
+	font-weight: 600;
+}
+
+.btnConfirm:hover {
+	background: #c0392b;
+}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,38 @@
+import styles from "./ConfirmDialog.module.css";
+
+type ConfirmDialogProps = {
+	title: string;
+	message: string;
+	confirmLabel: string;
+	cancelLabel: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+};
+
+function ConfirmDialog({
+	title,
+	message,
+	confirmLabel,
+	cancelLabel,
+	onConfirm,
+	onCancel,
+}: ConfirmDialogProps) {
+	return (
+		<div className={styles.overlay} onClick={onCancel}>
+			<div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+				<h3 className={styles.title}>{title}</h3>
+				<p className={styles.message}>{message}</p>
+				<div className={styles.actions}>
+					<button className={styles.btnCancel} onClick={onCancel}>
+						{cancelLabel}
+					</button>
+					<button className={styles.btnConfirm} onClick={onConfirm}>
+						{confirmLabel}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default ConfirmDialog;

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -47,6 +47,8 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 
 	// 再接続用にroomIdを保持
 	const roomIdRef = useRef<string | null>(initialRoomId ?? null);
+	// このマウントで自分のゲームが開始されたかを追跡（前のゲームのgameOverを無視するため）
+	const gameStartedRef = useRef(false);
 
 	// WebSocket接続とイベントハンドリング
 	useEffect(() => {
@@ -73,6 +75,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 			setGameState(dto.state);
 			// roomIdを保存（再接続に使用）
 			roomIdRef.current = dto.roomId;
+			gameStartedRef.current = true;
 			// 一時停止解除
 			if (isPaused) {
 				setIsPaused(false);
@@ -87,6 +90,8 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 			roomId: string;
 			reason?: string;
 		}) => {
+			// 前のゲームのgameOverを無視（updateStateを受信する前のgameOverは自分のゲームではない）
+			if (!gameStartedRef.current) return;
 			console.log("[GamePage] ゲーム終了:", data);
 			const myId = socket.id;
 			const isWinner =

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -259,7 +259,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 								onClick={handleBackToOnline}
 								style={{ marginTop: 16 }}
 							>
-								{t("game.backToOnline")}
+								{mode === "ai" ? t("game.playAgain") : t("game.backToOnline")}
 							</button>
 						</div>
 					)}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -111,7 +111,12 @@
 		"clickToStart": "Click to start controls",
 		"surrender": "Surrender",
 		"opponentDisconnected": "Opponent disconnected",
-		"waitingForReconnect": "Waiting for opponent to reconnect..."
+		"waitingForReconnect": "Waiting for opponent to reconnect...",
+		"playAgain": "Play Again",
+		"switchConfirmTitle": "Game in Progress",
+		"switchConfirmMessage": "Are you sure you want to leave the current game? Leaving will count as a loss.",
+		"switchConfirmOk": "Leave Game",
+		"switchConfirmCancel": "Cancel"
 	},
 	"online": {
 		"status": "Status",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -111,7 +111,12 @@
 		"clickToStart": "Cliquez pour commencer",
 		"surrender": "Abandonner",
 		"opponentDisconnected": "L'adversaire s'est déconnecté",
-		"waitingForReconnect": "En attente de la reconnexion de l'adversaire..."
+		"waitingForReconnect": "En attente de la reconnexion de l'adversaire...",
+		"playAgain": "Rejouer",
+		"switchConfirmTitle": "Partie en cours",
+		"switchConfirmMessage": "Voulez-vous quitter la partie en cours ? Quitter comptera comme une défaite.",
+		"switchConfirmOk": "Quitter la partie",
+		"switchConfirmCancel": "Annuler"
 	},
 	"online": {
 		"status": "Statut",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -111,7 +111,12 @@
 		"clickToStart": "クリックして操作を開始",
 		"surrender": "降参",
 		"opponentDisconnected": "相手が切断しました",
-		"waitingForReconnect": "相手の再接続を待っています..."
+		"waitingForReconnect": "相手の再接続を待っています...",
+		"playAgain": "もう一度プレイ",
+		"switchConfirmTitle": "対戦中です",
+		"switchConfirmMessage": "現在の対戦を中断して移動しますか？中断した場合、敗北として記録されます。",
+		"switchConfirmOk": "中断して移動",
+		"switchConfirmCancel": "キャンセル"
 	},
 	"online": {
 		"status": "ステータス",

--- a/package-lock.json
+++ b/package-lock.json
@@ -945,9 +945,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Summary

ゲームプレイ中のUX改善を行うPRです。　対応issue #62 

- **モード切替時の確認ダイアログ**: ゲーム中（AI/Online）にサイドバーで別モードに切り替えようとすると、確認ポップアップを表示。承諾するとsurrenderを送信して遷移する
- **AI再戦（もう一度プレイ）ボタン**: AIモードのゲーム終了後に「もう一度プレイ」ボタンで再戦可能。Reactの`key`によるコンポーネント再マウントでゲーム状態をリセット
- **パッケージ脆弱性の修正**: `npm audit fix`による依存パッケージの更新

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `ConfirmDialog.tsx` / `.module.css` | 汎用確認ダイアログコンポーネントを新規作成 |
| `App.tsx` | `handleNavigation()`による遷移制御、`aiGameKey`による再マウント、`ConfirmDialog`の組み込み |
| `GamePage.tsx` | `gameStartedRef`による不正なgameOver防止、ボタンラベルのモード分岐 |
| `en.json` / `fr.json` / `ja.json` | 確認ダイアログ・再戦ボタンの翻訳キー追加 |
| `package-lock.json` (x2) | axios, vite, brace-expansion等のセキュリティ更新 |

## Test plan

- [ ] AIモードでゲーム終了後「もう一度プレイ」を押して再戦できることを確認
- [ ] AI対戦中にサイドバーで「オンライン」を押すと確認ダイアログが表示されることを確認
- [ ] 確認ダイアログで「キャンセル」を押すとゲームが継続することを確認
- [ ] 確認ダイアログで「中断して移動」を押すとsurrenderされ遷移することを確認
- [ ] Online対戦中にサイドバーで「AI」を押しても同様にダイアログが表示されることを確認
- [ ] ゲーム中でない状態ではダイアログなしで即遷移することを確認

## スクリーンショット

- AIモード→オンラインモード
<img width="925" height="581" alt="image" src="https://github.com/user-attachments/assets/9d1f63a6-827d-4d2c-8f41-d9dceb0b4ff1" />

- オンラインモード→AIモード
<img width="678" height="497" alt="image" src="https://github.com/user-attachments/assets/f40e435f-a2e2-4f77-b159-d4840e086728" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)