### PR TITLE
feat: M2 DB設計 - マイグレーション実行環境を追加

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,10 @@
 		"start": "node dist/app/src/main",
 		"start:dev": "nest start --watch --exec 'node dist/app/src/main'",
 		"build": "nest build",
-		"clean": "rm -rf dist && rm -f /shared/*.js /shared/*.d.ts /shared/*.map"
+		"clean": "rm -rf dist && rm -f /shared/*.js /shared/*.d.ts /shared/*.map",
+		"migration:run": "typeorm migration:run -d dist/app/src/data-source.js",
+		"migration:revert": "typeorm migration:revert -d dist/app/src/data-source.js",
+		"migration:show": "typeorm migration:show -d dist/app/src/data-source.js"
 	},
 	"dependencies": {
 		"@nestjs/common": "^11.1.17",

--- a/backend/src/chat/chat.entity.ts
+++ b/backend/src/chat/chat.entity.ts
@@ -7,7 +7,7 @@ import {
 } from "typeorm";
 import { ChatMessage } from "../../../shared/chat.interface";
 
-@Entity() // 「これはDBのテーブルですよ」というラベル
+@Entity("chat") // 「これはDBのテーブルですよ」というラベル
 export class Chat implements ChatMessage {
 	@PrimaryGeneratedColumn() // 自動で増えるID（1, 2, 3...）
 	id: number;

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,0 +1,20 @@
+import { DataSource } from "typeorm";
+
+// TypeORM CLI 専用の DataSource 設定
+// NestJS アプリ起動時には使われず、migration:run / migration:revert / migration:show コマンドで使用する
+//
+// database.config.ts との違い:
+//   - synchronize: false  → 自動同期を無効化（マイグレーションで手動管理）
+//   - entities/migrations → コンパイル済み JS ファイルのパスを指定（ts-node 不要）
+export const AppDataSource = new DataSource({
+	type: "postgres",
+	host: process.env.DATABASE_HOST || "postgres",
+	port: parseInt(process.env.DATABASE_PORT) || 5432,
+	username: process.env.DATABASE_USER || "transcendence",
+	password: process.env.DATABASE_PASSWORD || "password123",
+	database: process.env.DATABASE_NAME || "transcendence_db",
+	synchronize: false,
+	logging: true,
+	entities: ["dist/app/src/**/*.entity.js"],
+	migrations: ["dist/app/src/migrations/*.js"],
+});

--- a/backend/src/game/match-history.entity.ts
+++ b/backend/src/game/match-history.entity.ts
@@ -5,7 +5,7 @@ import {
 	CreateDateColumn,
 } from "typeorm";
 
-@Entity()
+@Entity("match_history")
 export class MatchHistory {
 	@PrimaryGeneratedColumn()
 	id: number;

--- a/backend/src/migrations/20260323-InitialSchema.ts
+++ b/backend/src/migrations/20260323-InitialSchema.ts
@@ -6,8 +6,8 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 // 現在は database.config.ts の synchronize: true で自動同期しているため
 // 開発中はこのファイルを直接実行する必要はありません。
 // 本番環境では synchronize を false にして、このマイグレーションを使用してください。
-export class InitialSchema20260323 implements MigrationInterface {
-	name = "InitialSchema20260323";
+export class InitialSchema1774270819000 implements MigrationInterface {
+	name = "InitialSchema1774270819000";
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		// =========================================================

--- a/backend/src/migrations/20260323-InitialSchema.ts
+++ b/backend/src/migrations/20260323-InitialSchema.ts
@@ -1,0 +1,145 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// 初期マイグレーション: 全テーブルを作成する
+// 実行タイミング: データベースを初めてセットアップするとき
+//
+// 現在は database.config.ts の synchronize: true で自動同期しているため
+// 開発中はこのファイルを直接実行する必要はありません。
+// 本番環境では synchronize を false にして、このマイグレーションを使用してください。
+export class InitialSchema20260323 implements MigrationInterface {
+	name = "InitialSchema20260323";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		// =========================================================
+		// 1. users テーブル
+		// 認証情報・アカウント情報を管理する中心テーブル
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "users" (
+                "id"                SERIAL PRIMARY KEY,
+                "username"          VARCHAR NOT NULL,
+                "password"          VARCHAR,
+                "forty_two_id"      VARCHAR,
+                "is_2fa_enabled"    BOOLEAN NOT NULL DEFAULT false,
+                "two_factor_secret" VARCHAR,
+                "created_at"        TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "UQ_users_username"      UNIQUE ("username"),
+                CONSTRAINT "UQ_users_forty_two_id"  UNIQUE ("forty_two_id")
+            )
+        `);
+
+		// =========================================================
+		// 2. profiles テーブル
+		// users と 1対1 のプロフィール情報
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "profiles" (
+                "id"            SERIAL PRIMARY KEY,
+                "user_id"       INTEGER NOT NULL,
+                "displayName"   VARCHAR(50),
+                "bio"           TEXT,
+                "avatarUrl"     VARCHAR,
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                "updatedAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "FK_profiles_user_id"
+                    FOREIGN KEY ("user_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE
+            )
+        `);
+
+		// =========================================================
+		// 3. friends テーブル
+		// 承認済みフレンド関係。(user_id, friend_id) はユニーク
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "friends" (
+                "id"            SERIAL PRIMARY KEY,
+                "user_id"       INTEGER NOT NULL,
+                "friend_id"     INTEGER NOT NULL,
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "FK_friends_user_id"
+                    FOREIGN KEY ("user_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE,
+                CONSTRAINT "FK_friends_friend_id"
+                    FOREIGN KEY ("friend_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE,
+                CONSTRAINT "UQ_friends_user_friend"
+                    UNIQUE ("user_id", "friend_id")
+            )
+        `);
+
+		// =========================================================
+		// 4. friend_requests テーブル
+		// フレンド申請中のレコード。status enum で状態を管理
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TYPE "friend_request_status_enum"
+                AS ENUM ('pending', 'accepted', 'rejected')
+        `);
+
+		await queryRunner.query(`
+            CREATE TABLE "friend_requests" (
+                "id"            SERIAL PRIMARY KEY,
+                "sender_id"     INTEGER NOT NULL,
+                "receiver_id"   INTEGER NOT NULL,
+                "status"        "friend_request_status_enum" NOT NULL DEFAULT 'pending',
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                "updatedAt"     TIMESTAMP NOT NULL DEFAULT now(),
+                CONSTRAINT "FK_friend_requests_sender_id"
+                    FOREIGN KEY ("sender_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE,
+                CONSTRAINT "FK_friend_requests_receiver_id"
+                    FOREIGN KEY ("receiver_id")
+                    REFERENCES "users" ("id")
+                    ON DELETE CASCADE
+            )
+        `);
+
+		// =========================================================
+		// 5. chat テーブル
+		// チャットメッセージの履歴
+		// sender は username の文字列（FK なし）
+		// → ユーザー削除後もメッセージ履歴を保持するため
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "chat" (
+                "id"        SERIAL PRIMARY KEY,
+                "sender"    VARCHAR NOT NULL,
+                "content"   TEXT NOT NULL,
+                "roomId"    VARCHAR NOT NULL,
+                "createdAt" TIMESTAMP NOT NULL DEFAULT now()
+            )
+        `);
+
+		// =========================================================
+		// 6. match_history テーブル
+		// 対戦履歴。winnerUserId/loserUserId は nullable
+		// → アカウント削除時に NULL に匿名化するため（FK制約なし）
+		// =========================================================
+		await queryRunner.query(`
+            CREATE TABLE "match_history" (
+                "id"            SERIAL PRIMARY KEY,
+                "winnerUserId"  INTEGER,
+                "loserUserId"   INTEGER,
+                "winnerScore"   INTEGER NOT NULL,
+                "loserScore"    INTEGER NOT NULL,
+                "createdAt"     TIMESTAMP NOT NULL DEFAULT now()
+            )
+        `);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		// 作成と逆順に削除する（外部キー制約の依存関係を考慮）
+		await queryRunner.query(`DROP TABLE IF EXISTS "match_history"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "chat"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "friend_requests"`);
+		await queryRunner.query(`DROP TYPE IF EXISTS "friend_request_status_enum"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "friends"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "profiles"`);
+		await queryRunner.query(`DROP TABLE IF EXISTS "users"`);
+	}
+}

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -1,0 +1,96 @@
+# ER図（ft_transcendence データベース設計）
+
+## テーブル一覧
+
+| テーブル名        | 対応 Entity     | 説明                              |
+| ----------------- | --------------- | --------------------------------- |
+| `users`           | `User`          | 認証情報・アカウント              |
+| `profiles`        | `Profile`       | プロフィール情報（users と 1対1） |
+| `friends`         | `Friend`        | フレンド関係（承認済み）          |
+| `friend_requests` | `FriendRequest` | フレンドリクエスト（申請中）      |
+| `chat`            | `Chat`          | チャットメッセージ                |
+| `match_history`   | `MatchHistory`  | 対戦履歴                          |
+
+## ER図
+
+```mermaid
+erDiagram
+    users {
+        int id PK "自動採番"
+        varchar username UK "ユーザー名（一意）"
+        varchar password "パスワードハッシュ（42OAuthは null）"
+        varchar forty_two_id UK "42のユーザーID（オプション）"
+        boolean is_2fa_enabled "2FA有効フラグ（default: false）"
+        varchar two_factor_secret "2FAシークレット（nullable）"
+        timestamp created_at "作成日時（自動）"
+    }
+
+    profiles {
+        int id PK "自動採番"
+        int user_id FK "users.id への外部キー"
+        varchar displayName "表示名（最大50文字、nullable）"
+        text bio "自己紹介（nullable）"
+        varchar avatarUrl "アバター画像URL（nullable）"
+        timestamp createdAt "作成日時（自動）"
+        timestamp updatedAt "更新日時（自動）"
+    }
+
+    friends {
+        int id PK "自動採番"
+        int user_id FK "users.id への外部キー"
+        int friend_id FK "users.id への外部キー"
+        timestamp createdAt "フレンド成立日時（自動）"
+    }
+
+    friend_requests {
+        int id PK "自動採番"
+        int sender_id FK "users.id（送信者）"
+        int receiver_id FK "users.id（受信者）"
+        enum status "pending / accepted / rejected"
+        timestamp createdAt "リクエスト送信日時（自動）"
+        timestamp updatedAt "更新日時（自動）"
+    }
+
+    chat {
+        int id PK "自動採番"
+        varchar sender "送信者のユーザー名"
+        text content "メッセージ本文"
+        varchar roomId "チャットルームID"
+        timestamp createdAt "送信日時（自動）"
+    }
+
+    match_history {
+        int id PK "自動採番"
+        int winnerUserId "勝者の users.id（nullable: 匿名化対応）"
+        int loserUserId "敗者の users.id（nullable: 匿名化対応）"
+        int winnerScore "勝者のスコア"
+        int loserScore "敗者のスコア"
+        timestamp createdAt "対戦日時（自動）"
+    }
+
+    users ||--|| profiles : "1対1（user_id → users.id）"
+    users ||--o{ friends : "user_id（フレンドの一方）"
+    users ||--o{ friends : "friend_id（フレンドの他方）"
+    users ||--o{ friend_requests : "sender_id（送信者）"
+    users ||--o{ friend_requests : "receiver_id（受信者）"
+```
+
+## リレーション説明
+
+| リレーション                | 種類           | 説明                                                                                                                     |
+| --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `users` ↔ `profiles`        | 1対1           | 1ユーザーに1プロフィール。ユーザー削除時にCASCADE                                                                        |
+| `users` ↔ `friends`         | 1対多（2経路） | `user_id` と `friend_id` の両方が `users` を参照。`(user_id, friend_id)` のペアはUNIQUE制約あり                          |
+| `users` ↔ `friend_requests` | 1対多（2経路） | `sender_id`（送信者）と `receiver_id`（受信者）が `users` を参照                                                         |
+| `chat`                      | 独立           | `sender` は `users.username` を文字列で保持（FK なし）。ユーザー削除時も履歴を保持                                       |
+| `match_history`             | 独立（疑似FK） | `winnerUserId`/`loserUserId` は `users.id` を参照するが、FK制約なし。削除済みユーザーの試合履歴を保持するため `nullable` |
+
+## 制約一覧
+
+| テーブル          | 制約           | 対象列                                      |
+| ----------------- | -------------- | ------------------------------------------- |
+| `users`           | UNIQUE         | `username`                                  |
+| `users`           | UNIQUE         | `forty_two_id`                              |
+| `profiles`        | UNIQUE（暗黙） | `user_id`（OneToOneのため）                 |
+| `friends`         | UNIQUE         | `(user_id, friend_id)`                      |
+| `friend_requests` | ENUM           | `status`: `pending`, `accepted`, `rejected` |


### PR DESCRIPTION
## 概要

M2（DB設計）の完成に向けて、マイグレーションファイルの動作確認と本番運用に必要な設定を追加しました。

---

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `docs/er-diagram.md` | ER図を追加 |
| `backend/src/migrations/20260323-InitialSchema.ts` | 初期マイグレーションを追加 / クラス名を TypeORM 0.3.x 準拠の形式に修正 |
| `backend/src/chat/chat.entity.ts` | テーブル名を明示 |
| `backend/src/game/match-history.entity.ts` | テーブル名を明示 |
| `backend/src/data-source.ts` | TypeORM CLI 用 DataSource 設定を新規作成 |
| `backend/package.json` | `migration:run` / `migration:revert` / `migration:show` スクリプトを追加 |

---

## 動作確認結果

### migration:run（up）実行後のテーブル一覧

```
 Schema |      Name       | Type
--------+-----------------+-------
 public | chat            | table
 public | friend_requests | table
 public | friends         | table
 public | match_history   | table
 public | migrations      | table  ← TypeORM 管理テーブル
 public | profiles        | table
 public | users           | table
(7 rows)
```

✅ 6テーブル + migrations テーブル 計7テーブルが正常に作成されました

### migration:revert（down）実行後のテーブル一覧

```
 Schema |    Name    | Type
--------+------------+-------
 public | migrations | table
(1 row)
```

✅ 6テーブルが正常にロールバックされました

### スキーマ変更を含む revert のテスト

既存テーブルへのカラム追加 / 削除を伴う migration:002 を使用して「revert 後に既存データが保持されるか」を確認しました。

| 確認項目 | 結果 |
|---|---|
| migration:run で email カラムが追加される | ✅ |
| alice / bob のデータが保持されたまま email カラムが追加される | ✅ |
| migration:revert で email カラムが削除される | ✅ |
| **revert 後も alice / bob のデータが保持されている** | ✅ |

※ 初期マイグレーション（migration:001）は `CREATE TABLE` のため、revert 時にはデータも削除されます。データを保持したままロールバックするテストは migration:002 以降が対象です。

---

## 自分で確認したい場合

> ⚠️ DBの全データが削除されます。実行前にご注意ください。

**事前準備: synchronize を false にしてバックエンドを再起動**

`backend/src/database.config.ts` の `synchronize: true` を `false` に変更して再起動します。
```bash
docker restart trans_backend
```

**事前準備: クリーンな状態にする**
```bash
docker exec trans_postgres psql -U transcendence -d transcendence_db -c "
  DROP TABLE IF EXISTS friend_requests, friends, match_history, chat, profiles, users CASCADE;
  DROP TYPE  IF EXISTS friend_request_status_enum CASCADE;
  DELETE FROM migrations;
"
```

**1. migration:run でテーブルを作成**
```bash
docker exec trans_backend npm run migration:run
```

**2. テーブル確認（7テーブル）**
```bash
docker exec trans_postgres psql -U transcendence -d transcendence_db -c "\dt"
```

**3. データを INSERT**
```bash
docker exec trans_postgres psql -U transcendence -d transcendence_db -c "
  INSERT INTO users (username, password) VALUES ('alice', 'hash1'), ('bob', 'hash2');
"
```

**4. migration:002 を作成（スキーマ変更のテスト用）**

`backend/src/migrations/` に新規ファイルを作成します。
`20260323-InitialSchema.ts` を参考に、users テーブルに email カラムを追加する `up()` / `down()` を持つファイルを作成します。
例: `20260412-AddEmailToUsers.ts`

**5. migration:run で email カラムを追加**
```bash
docker exec trans_backend npm run migration:run
```

**6. スキーマ確認（email カラムが存在する）**
```bash
docker exec trans_postgres psql -U transcendence -d transcendence_db -c "\d users"
```

**7. migration:revert で email カラムを削除**
```bash
docker exec trans_backend npm run migration:revert
```

**8. スキーマ確認（email カラムが消えている）**
```bash
docker exec trans_postgres psql -U transcendence -d transcendence_db -c "\d users"
```

**9. データ確認（alice / bob が残っている ← revert の本来の確認）**
```bash
docker exec trans_postgres psql -U transcendence -d transcendence_db -c "
  SELECT id, username FROM users;
"
```

**確認後: synchronize を true に戻してバックエンドを再起動**
```bash
docker restart trans_backend
```