### PR TITLE
fix: AIの挙動をより人間らしく改善し、二重再接続の問題を修正

### DIFF
--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -26,8 +26,12 @@ import {
 	PREDICTION_NOT_SET,
 	UPPER_LIMIT,
 	RE_PREDICT_PROBABILITY,
-	DEFAULT_DIFFICULTY,
-	BASE_REACTION_DELAY,
+	MIN_REACTION_DELAY,
+	MAX_REACTION_DELAY,
+	NEGATIVE_ERROR,
+	POSITIVE_ERROR,
+	SECOND,
+	FPS,
 } from "../../../shared/game.constants";
 
 // サーバー内部でのみ管理する物理パラメータ（フロントには送らない）
@@ -120,7 +124,7 @@ export class GameService {
 
 		const interval = setInterval(() => {
 			this.AIgameLoop(roomId, server);
-		}, 1000 / 60);
+		}, SECOND / FPS);
 
 		initialState.interval = interval;
 		this.AIgames.set(roomId, initialState);
@@ -162,8 +166,7 @@ export class GameService {
 				game.dy = (hitPos - 0.5) * ANGLE_CHANGE;
 				game.dx *= SPEED_CHANGE;
 				game.AiPrediction = PREDICTION_NOT_SET;
-				const delay =
-					randomInt(0, BASE_REACTION_DELAY + 1) / DEFAULT_DIFFICULTY;
+				const delay = randomInt(MIN_REACTION_DELAY, MAX_REACTION_DELAY + 1);
 				game.AiNextReaction = Date.now() + delay;
 				console.log(
 					`[Game.Service] AINextReaction is going to be in ${delay} milli-seconds`,
@@ -240,7 +243,7 @@ export class GameService {
 			Math.random() < RE_PREDICT_PROBABILITY
 		) {
 			game.AiPrediction = this.AIMakePrediction(game);
-			console.log(`[Game.Service] AI new prediction: ${game.AiPrediction}`);
+			console.log(`[Game.Service] AI new prediction: ${game.AiPrediction}\n`);
 		}
 
 		const targetY = Math.max(game.AiPrediction - PAD_LENGTH / 2, 0);
@@ -268,13 +271,10 @@ export class GameService {
 				dy *= -1;
 			}
 		}
-		//adding error range
-		const difficulty = DEFAULT_DIFFICULTY;
-		const errorRange = Math.floor(PAD_LENGTH * difficulty);
-		const randomness = randomInt(-errorRange, errorRange + 1);
-		console.log(`[Game.Service] randomness: ${randomness}`);
+		const error = randomInt(NEGATIVE_ERROR, POSITIVE_ERROR + 1);
+		console.log(`[Game.Service] error: ${error}`);
 		console.log(`[Game.Service] real prediction: ${simY}`);
-		simY += randomness;
+		simY += error;
 
 		if (simY > FIELD_HEIGHT) {
 			return FIELD_HEIGHT;
@@ -368,7 +368,7 @@ export class GameService {
 
 		const interval = setInterval(() => {
 			this.gameLoop(roomId, server);
-		}, 1000 / 60);
+		}, SECOND / FPS);
 
 		initialState.interval = interval;
 
@@ -721,7 +721,7 @@ export class GameService {
 		if (!game.interval) {
 			game.interval = setInterval(
 				() => this.gameLoop(roomId, server),
-				1000 / 60,
+				SECOND / FPS,
 			);
 		}
 

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -574,6 +574,27 @@ export class GameService {
 					game.interval = null;
 				}
 
+				// if both player disconnected and nobody came back,
+				// completely abort the game.
+				if (!game.p1Connected && !game.p2Connected) {
+					console.log(
+						`[GameService] Both players were disconnected. Aborting game`,
+					);
+					server.to(roomId).emit("gameOver", {
+						winner: null,
+						reason: "both_disconnected",
+						roomId,
+					});
+					this.onlineGames.delete(roomId);
+					this.userIdToRoom.delete(game.p1UserId);
+					this.userIdToRoom.delete(game.p2UserId);
+					this.socketToPlayer.delete(game.p1SocketId);
+					this.socketToPlayer.delete(game.p2SocketId);
+					this.disconnectedPlayers.delete(game.p1UserId);
+					this.disconnectedPlayers.delete(game.p2UserId);
+					return;
+				}
+
 				const winnerSocketId = game.p1Connected
 					? game.p1SocketId
 					: game.p2SocketId;

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { MatchHistory } from "./match-history.entity";
 import { GameState, GameStateDto } from "../../../shared/game.interface";
-import { randomUUID } from "crypto";
+import { randomUUID, randomInt } from "crypto";
 import {
 	FIELD_WIDTH,
 	FIELD_HEIGHT,
@@ -23,6 +23,11 @@ import {
 	AI_SOCKET_ID,
 	AI_USER_ID,
 	GRACE_TIME,
+	PREDICTION_NOT_SET,
+	UPPER_LIMIT,
+	RE_PREDICT_PROBABILITY,
+	DEFAULT_DIFFICULTY,
+	BASE_REACTION_DELAY,
 } from "../../../shared/game.constants";
 
 // サーバー内部でのみ管理する物理パラメータ（フロントには送らない）
@@ -34,6 +39,10 @@ interface GameInternalState extends GameState {
 	p2SocketId: string;
 	p1UserId: number; // 認証済みユーザーのDB ID（統計用）
 	p2UserId: number;
+	p1Connected: boolean;
+	p2Connected: boolean;
+	AiPrediction: number;
+	AiNextReaction: number;
 	interval: NodeJS.Timeout | null;
 	disconnectTimer?: NodeJS.Timeout | null;
 }
@@ -102,6 +111,10 @@ export class GameService {
 			p2SocketId: AI_SOCKET_ID,
 			p1UserId: playerId,
 			p2UserId: AI_USER_ID,
+			p1Connected: true,
+			p2Connected: true,
+			AiPrediction: PREDICTION_NOT_SET,
+			AiNextReaction: 0,
 			interval: null,
 		};
 
@@ -148,34 +161,28 @@ export class GameService {
 				const hitPos = (game.ball.y - game.leftPaddleY) / PAD_LENGTH;
 				game.dy = (hitPos - 0.5) * ANGLE_CHANGE;
 				game.dx *= SPEED_CHANGE;
+				game.AiPrediction = PREDICTION_NOT_SET;
+				const delay =
+					randomInt(0, BASE_REACTION_DELAY + 1) / DEFAULT_DIFFICULTY;
+				game.AiNextReaction = Date.now() + delay;
+				console.log(
+					`[Game.Service] AINextReaction is going to be in ${delay} milli-seconds`,
+				);
 			}
 		}
 
 		// 4. AI paddle behavior (provvisory)
-		const aiSpeed = 3;
-		if (game.dx > 0) {
-			if (game.ball.y > game.rightPaddleY + PAD_LENGTH / 2) {
-				game.rightPaddleY = Math.min(
-					FIELD_HEIGHT - PAD_LENGTH,
-					game.rightPaddleY + aiSpeed,
-				);
-			} else {
-				game.rightPaddleY = Math.max(0, game.rightPaddleY - aiSpeed);
-			}
+		this.AIBehavior(game);
 
-			// AI paddle collision
+		// AI paddle collision
+		if (game.ball.x >= RIGHTPAD_LEFTMOST && game.ball.x <= RIGHTPAD_RIGHTMOST) {
 			if (
-				game.ball.x >= RIGHTPAD_LEFTMOST &&
-				game.ball.x <= RIGHTPAD_RIGHTMOST
+				game.ball.y >= game.rightPaddleY &&
+				game.ball.y <= game.rightPaddleY + PAD_LENGTH
 			) {
-				if (
-					game.ball.y >= game.rightPaddleY &&
-					game.ball.y <= game.rightPaddleY + PAD_LENGTH
-				) {
-					const hitPos = (game.ball.y - game.rightPaddleY) / PAD_LENGTH;
-					game.dy = (hitPos - 0.5) * ANGLE_CHANGE;
-					game.dx *= SPEED_CHANGE;
-				}
+				const hitPos = (game.ball.y - game.rightPaddleY) / PAD_LENGTH;
+				game.dy = (hitPos - 0.5) * ANGLE_CHANGE;
+				game.dx *= SPEED_CHANGE;
 			}
 		}
 
@@ -186,6 +193,7 @@ export class GameService {
 
 			game.ball = { ...FIELD_CENTER };
 			game.dx = game.dx > 0 ? -SPEED_BASE : SPEED_BASE;
+			game.AiPrediction = PREDICTION_NOT_SET;
 			game.dy = SPEED_BASE;
 		}
 
@@ -210,6 +218,71 @@ export class GameService {
 		}
 
 		server.to(roomId).emit("updateState", this.toDto(game));
+	}
+
+	AIBehavior(game: GameInternalState) {
+		if (game.dx < 0) {
+			if (Math.abs(game.rightPaddleY - STARTING_POSITION) <= PAD_SPEED) {
+				return;
+			} else if (game.rightPaddleY < STARTING_POSITION) {
+				game.rightPaddleY += PAD_SPEED;
+			} else {
+				game.rightPaddleY -= PAD_SPEED;
+			}
+			return;
+		}
+
+		if (Date.now() < game.AiNextReaction) {
+			return;
+		}
+		if (
+			game.AiPrediction == PREDICTION_NOT_SET ||
+			Math.random() < RE_PREDICT_PROBABILITY
+		) {
+			game.AiPrediction = this.AIMakePrediction(game);
+			console.log(`[Game.Service] AI new prediction: ${game.AiPrediction}`);
+		}
+
+		const targetY = Math.max(game.AiPrediction - PAD_LENGTH / 2, 0);
+		if (Math.abs(game.rightPaddleY - targetY) <= PAD_SPEED) {
+			game.rightPaddleY = Math.max(
+				0,
+				Math.min(FIELD_HEIGHT - PAD_LENGTH, targetY),
+			);
+		} else if (game.rightPaddleY < targetY) {
+			game.rightPaddleY = Math.min(game.rightPaddleY + PAD_SPEED, UPPER_LIMIT);
+		} else {
+			game.rightPaddleY = Math.max(game.rightPaddleY - PAD_SPEED, 0);
+		}
+	}
+
+	AIMakePrediction(game: GameInternalState): number {
+		let simX = game.ball.x;
+		let simY = game.ball.y;
+		const dx = game.dx;
+		let dy = game.dy;
+		while (simX < RIGHTPAD_LEFTMOST) {
+			simX += dx;
+			simY += dy;
+			if ((simY <= 0 && dy < 0) || (simY >= FIELD_HEIGHT && dy > 0)) {
+				dy *= -1;
+			}
+		}
+		//adding error range
+		const difficulty = DEFAULT_DIFFICULTY;
+		const errorRange = Math.floor(PAD_LENGTH * difficulty);
+		const randomness = randomInt(-errorRange, errorRange + 1);
+		console.log(`[Game.Service] randomness: ${randomness}`);
+		console.log(`[Game.Service] real prediction: ${simY}`);
+		simY += randomness;
+
+		if (simY > FIELD_HEIGHT) {
+			return FIELD_HEIGHT;
+		}
+		if (simY < 0) {
+			return 0;
+		}
+		return Math.floor(simY);
 	}
 
 	// マッチメイキング
@@ -286,6 +359,10 @@ export class GameService {
 			p2SocketId,
 			p1UserId,
 			p2UserId,
+			p1Connected: true,
+			p2Connected: true,
+			AiPrediction: PREDICTION_NOT_SET,
+			AiNextReaction: 0,
 			interval: null,
 		};
 
@@ -439,15 +516,9 @@ export class GameService {
 		if (!game) return;
 
 		if (game.p1UserId === playerId) {
-			game.leftPaddleY = Math.min(
-				FIELD_HEIGHT - PAD_LENGTH,
-				game.leftPaddleY + PAD_SPEED,
-			);
+			game.leftPaddleY = Math.min(UPPER_LIMIT, game.leftPaddleY + PAD_SPEED);
 		} else if (game.p2UserId === playerId) {
-			game.rightPaddleY = Math.min(
-				FIELD_HEIGHT - PAD_LENGTH,
-				game.rightPaddleY + PAD_SPEED,
-			);
+			game.rightPaddleY = Math.min(UPPER_LIMIT, game.rightPaddleY + PAD_SPEED);
 		}
 	}
 
@@ -483,10 +554,12 @@ export class GameService {
 				Array.from(this.disconnectedPlayers),
 			);
 
+			if (game.p1UserId === userId) {
+				game.p1Connected = false;
+			} else {
+				game.p2Connected = false;
+			}
 			game.isPaused = true;
-
-			const otherSocketId =
-				game.p1SocketId === client.id ? game.p2SocketId : game.p1SocketId;
 			server.to(roomId).emit("playerDisconnected", { userId });
 
 			if (game.disconnectTimer) clearTimeout(game.disconnectTimer);
@@ -496,11 +569,17 @@ export class GameService {
 					`[GameService] Grace period expired for player ${userId}, ending match ${roomId}`,
 				);
 
-				clearInterval(game.interval);
-				game.interval = null;
+				if (game.interval) {
+					clearInterval(game.interval);
+					game.interval = null;
+				}
 
-				const winnerSocketId = otherSocketId;
-				const loserSocketId = client.id;
+				const winnerSocketId = game.p1Connected
+					? game.p1SocketId
+					: game.p2SocketId;
+				const loserSocketId = game.p1Connected
+					? game.p2SocketId
+					: game.p1SocketId;
 
 				server.to(roomId).emit("gameOver", {
 					winner: winnerSocketId,
@@ -526,7 +605,10 @@ export class GameService {
 				);
 
 				console.log(
-					`[Game.Service] saving result: Winner->${winnerUserId} Loser->${loserUserId}`,
+					`[Game.Service] saving result: Winner->${winnerUserId} Socket->${winnerSocketId}`,
+				);
+				console.log(
+					`[Game.Service] saving result: Loser->${loserUserId} Socket->${loserSocketId}`,
 				);
 
 				this.onlineGames.delete(roomId);
@@ -573,7 +655,6 @@ export class GameService {
 			client.emit("reconnectFailed", { reason: "game_not_found" });
 			return;
 		}
-
 		// userId OK?
 		const isP1 = game.p1UserId === userId;
 		const isP2 = game.p2UserId === userId;
@@ -581,14 +662,19 @@ export class GameService {
 			client.emit("reconnectFailed", { reason: "not_your_game" });
 			return;
 		}
-
 		if (!game.interval && !game.disconnectTimer) {
 			client.emit("reconnectFailed", { reason: "game_already_finished" });
 			return;
 		}
-		if (isP1) game.p1SocketId = client.id;
-		if (isP2) game.p2SocketId = client.id;
 
+		if (isP1) {
+			game.p1SocketId = client.id;
+			game.p1Connected = true;
+		}
+		if (isP2) {
+			game.p2SocketId = client.id;
+			game.p2Connected = true;
+		}
 		console.log(
 			`[GameService] Player ${userId} reconnected: new socket -> ${client.id} room-> ${roomId}`,
 		);
@@ -601,18 +687,6 @@ export class GameService {
 		// join the room again
 		// Joinやり直します
 		client.join(roomId);
-
-		// clear timer if still not clear
-		// ClearTimerリセット
-		if (game.disconnectTimer) {
-			clearTimeout(game.disconnectTimer);
-			game.disconnectTimer = null;
-		}
-
-		// resume game
-		// もう一度Gameをスタートします
-		game.isPaused = false;
-
 		// notify the other player
 		// 待ってた相手に知らせ送ります
 		server.to(roomId).emit("playerReconnected", { userId });
@@ -628,6 +702,18 @@ export class GameService {
 				() => this.gameLoop(roomId, server),
 				1000 / 60,
 			);
+		}
+
+		// resume game
+		// もう一度Gameをスタートします
+		if (game.p1Connected && game.p2Connected) {
+			game.isPaused = false;
+			// clear timer if still not clear
+			// ClearTimerリセット
+			if (game.disconnectTimer) {
+				clearTimeout(game.disconnectTimer);
+				game.disconnectTimer = null;
+			}
 		}
 	}
 

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -752,6 +752,28 @@ export class GameService {
 		}
 		const isP1 = game.p1UserId === userId;
 
+		// if somebody surrenders while the other player is not connected,
+		// completely abort the game.
+		if ((isP1 && !game.p2Connected) || (!isP1 && !game.p1Connected)) {
+			console.log(
+				`[GameService] The other player was already disconnected. Aborting game`,
+			);
+			server.to(roomId).emit("gameOver", {
+				winner: null,
+				reason: "both_disconnected",
+				roomId,
+			});
+			if (game.disconnectTimer) clearTimeout(game.disconnectTimer);
+			this.onlineGames.delete(roomId);
+			this.userIdToRoom.delete(game.p1UserId);
+			this.userIdToRoom.delete(game.p2UserId);
+			this.socketToPlayer.delete(game.p1SocketId);
+			this.socketToPlayer.delete(game.p2SocketId);
+			this.disconnectedPlayers.delete(game.p1UserId);
+			this.disconnectedPlayers.delete(game.p2UserId);
+			return;
+		}
+
 		const winnerUserId = isP1 ? game.p2UserId : game.p1UserId;
 		const loserUserId = isP1 ? game.p1UserId : game.p2UserId;
 		const winnerScore = isP1 ? game.rightScore : game.leftScore;

--- a/shared/game.constants.ts
+++ b/shared/game.constants.ts
@@ -1,4 +1,6 @@
 // frontと同じにするべきだった分 start。。。
+export const SECOND = 1000;
+export const FPS = 60;
 export const FIELD_WIDTH = 800;
 export const FIELD_HEIGHT = 600;
 export const PAD_SPEED = 8;
@@ -7,7 +9,7 @@ export const PAD_LENGTH = 100;
 export const PAD_BORDER_DIST = 40;
 export const AI_SOCKET_ID = null;
 export const AI_USER_ID = -1;
-export const GRACE_TIME = 15000;
+export const GRACE_TIME = SECOND * 10;
 // 。。。finish
 
 export const FIELD_CENTER = { x: FIELD_WIDTH / 2, y: FIELD_HEIGHT / 2 };
@@ -22,10 +24,12 @@ export const SPEED_BASE = 5;
 export const ANGLE_CHANGE = SPEED_BASE * 4;
 export const SPEED_CHANGE = -1.1;
 export const MAX_SCORE = 11;
+
 // AI settings
 export const PREDICTION_NOT_SET = -1;
-export const RE_PREDICT_PROBABILITY = 0.1;
-export const DEFAULT_DIFFICULTY = 0.5;
-export const MAX_DIFFICULTY = 0.25;
-export const MIN_DIFFICULTY = 1.0;
-export const BASE_REACTION_DELAY = 300;
+export const RE_PREDICT_PROBABILITY = 0.05;
+export const DIFFICULTY = 1; // (0 -> very strong) (2 -> very weak)
+export const POSITIVE_ERROR = PAD_HALF + PAD_LENGTH * DIFFICULTY;
+export const NEGATIVE_ERROR = -POSITIVE_ERROR;
+export const MIN_REACTION_DELAY = SECOND / 10;
+export const MAX_REACTION_DELAY = MIN_REACTION_DELAY + DIFFICULTY * SECOND;

--- a/shared/game.constants.ts
+++ b/shared/game.constants.ts
@@ -22,3 +22,10 @@ export const SPEED_BASE = 5;
 export const ANGLE_CHANGE = SPEED_BASE * 4;
 export const SPEED_CHANGE = -1.1;
 export const MAX_SCORE = 11;
+// AI settings
+export const PREDICTION_NOT_SET = -1;
+export const RE_PREDICT_PROBABILITY = 0.1;
+export const DEFAULT_DIFFICULTY = 0.5;
+export const MAX_DIFFICULTY = 0.25;
+export const MIN_DIFFICULTY = 1.0;
+export const BASE_REACTION_DELAY = 300;


### PR DESCRIPTION
### AIの新しい挙動

* ボールがプレイヤーに向かっている間、AIは中央の位置に戻ろうとします。
* プレイヤーがボールを打ち返した直後、AIは動き出す前に可変の反応時間をシミュレートします。
* 上記の反応時間が経過すると、AIはボールをインターセプトできる位置を計算します。
* インターセプト位置を計算した後、その位置に対して可変の誤差を加え、それに基づいて移動します。
* また、同じラリー中に複数回誤差を再計算することがあり、迷いのある挙動をシミュレートします。

### バグ修正

* 以前は、両プレイヤーが切断された場合でも、どちらか一方が再接続するとゲームループが再開されていました。
* 現在は、両方のプレイヤーが再接続しない限り再開されません。GRACE_PERIOD経過後は、再接続したプレイヤーに勝利が与えられます。

### 備考

* 現状、どちらのプレイヤーも再接続しなかった場合、最後に切断したプレイヤーに勝利が与えられますが、試合自体を無効にする方が適切かもしれません。
* また、片方のプレイヤーのみが再接続した場合、そのプレイヤーに勝利が与えられますが、ブラウザ上でメッセージが表示されていないようです。フロントエンドの問題か、こちらの実装ミスの可能性があります。
