### PR TITLE
feat(frontend): Bootstrap 5移行・ホーム画面追加・統計修正 [M9]

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
 		"start:dev": "nest start --watch --exec 'node dist/app/src/main'",
 		"build": "nest build",
 		"clean": "rm -rf dist && rm -f /shared/*.js /shared/*.d.ts /shared/*.map",
-		"test": "ln -sf /app/node_modules /test/node_modules 2>/dev/null; vitest run"
+		"test": "ln -sf /app/node_modules /test/node_modules 2>/dev/null; vitest run",
 		"migration:run": "typeorm migration:run -d dist/app/src/data-source.js",
 		"migration:revert": "typeorm migration:revert -d dist/app/src/data-source.js",
 		"migration:show": "typeorm migration:show -d dist/app/src/data-source.js",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -270,6 +270,135 @@ h2 {
 	margin-bottom: 20px;
 }
 
+/* ── Home Page ─────────────────────────────────── */
+.home-content {
+	padding: 2rem 2.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 2.5rem;
+}
+
+.home-hero {
+	display: flex;
+	align-items: center;
+	gap: 2.5rem;
+	flex-wrap: wrap;
+}
+
+.home-hero-text {
+	flex: 1;
+	min-width: 280px;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.home-welcome-label {
+	font-size: 12px;
+	color: #888;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.home-welcome-name {
+	font-size: 26px;
+	font-weight: 500;
+	line-height: 1.2;
+}
+
+.home-username {
+	color: #534ab7;
+}
+
+.home-desc {
+	font-size: 14px;
+	line-height: 1.7;
+	color: #666;
+	max-width: 400px;
+}
+
+.home-cta-row {
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-top: 0.25rem;
+}
+
+.home-cta-primary {
+	padding: 10px 20px;
+	background: #534ab7;
+	color: #fff;
+	border: none;
+	border-radius: 8px;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: opacity 0.15s;
+}
+
+.home-cta-primary:hover {
+	opacity: 0.85;
+}
+
+.home-cta-secondary {
+	padding: 10px 20px;
+	background: transparent;
+	color: inherit;
+	border: 1px solid #ccc;
+	border-radius: 8px;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.home-cta-secondary:hover {
+	background: rgba(0, 0, 0, 0.05);
+}
+
+.home-pong-illustration {
+	flex-shrink: 0;
+}
+
+.home-info-cards {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.home-info-card {
+	border: 1px solid #e0e0e0;
+	border-radius: 12px;
+	padding: 1rem 1.25rem;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.home-card-title {
+	font-size: 14px;
+	font-weight: 500;
+}
+
+.home-card-body {
+	font-size: 13px;
+	color: #666;
+	line-height: 1.6;
+}
+
+@media (max-width: 600px) {
+	.home-content {
+		padding: 1.5rem 1rem;
+	}
+	.home-info-cards {
+		grid-template-columns: 1fr;
+	}
+	.home-pong-illustration svg {
+		width: 100%;
+		height: auto;
+	}
+}
+
 /* ============================================ */
 /* プロフィールページ */
 /* ============================================ */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -77,6 +77,10 @@ h2 {
 	font-size: 1.5rem;
 }
 
+/* ============================================ */
+/* 認証タブ */
+/* ============================================ */
+
 .tabs {
 	display: flex;
 	gap: 10px;
@@ -100,6 +104,7 @@ h2 {
 	color: white;
 }
 
+/* メッセージ表示 */
 .message {
 	margin-top: 15px;
 	padding: 10px;
@@ -109,25 +114,10 @@ h2 {
 	color: #555;
 }
 
-.user-info {
-	text-align: center;
-}
-
-.user-info h2 {
-	color: #667eea;
-	margin-bottom: 10px;
-}
-
-.user-info p {
-	margin-bottom: 20px;
-	color: #666;
-}
-
 /* ============================================ */
-/* ログイン後のレイアウト（マイルストーン#3） */
-/* ============================================ */
-
 /* サイドバーナビゲーション */
+/* ============================================ */
+
 .sidebar {
 	width: 250px;
 	min-width: 250px;
@@ -138,13 +128,6 @@ h2 {
 	flex-direction: column;
 	transition: opacity 0.6s ease 0.3s;
 	overflow-y: auto;
-}
-
-.sidebar-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 40px;
 }
 
 .sidebar h1 {
@@ -170,17 +153,6 @@ h2 {
 	background: rgba(255, 255, 255, 0.3);
 }
 
-.auth-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 30px;
-}
-
-.auth-header h1 {
-	margin-bottom: 0;
-}
-
 .auth-content .lang-toggle {
 	background: rgba(102, 126, 234, 0.1);
 	border: 1px solid rgba(102, 126, 234, 0.3);
@@ -191,17 +163,12 @@ h2 {
 	background: rgba(102, 126, 234, 0.2);
 }
 
-.nav-menu {
-	list-style: none;
-	flex: 1;
-	padding-left: 0;
-}
-
-.nav-menu li {
+/* サイドバーナビメニュー */
+.sidebar li {
 	margin-bottom: 10px;
 }
 
-.nav-menu button {
+.sidebar ul button {
 	width: 100%;
 	padding: 12px 20px;
 	background: rgba(255, 255, 255, 0.1);
@@ -215,17 +182,13 @@ h2 {
 	transition: all 0.3s;
 }
 
-.nav-menu button:hover {
+.sidebar ul button:hover {
 	background: rgba(255, 255, 255, 0.2);
 }
 
-.nav-menu button.active {
+.sidebar ul button.active {
 	background: rgba(255, 255, 255, 0.3);
 	font-weight: bold;
-}
-
-.sidebar-footer {
-	margin-top: auto;
 }
 
 /* メインコンテンツエリア */
@@ -236,12 +199,6 @@ h2 {
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-}
-
-.main-content-inner {
-	flex: 1;
-	padding: 40px;
-	overflow-y: auto;
 }
 
 /* ページコンテンツのフェードイン */
@@ -256,18 +213,8 @@ h2 {
 	}
 }
 
-.main-content-inner > * {
+.main-content > div:first-child > * {
 	animation: fadeIn 0.3s ease-out;
-}
-
-.home {
-	text-align: center;
-	padding: 40px;
-}
-
-.home h2 {
-	color: #667eea;
-	margin-bottom: 20px;
 }
 
 /* ── Home Page ─────────────────────────────────── */
@@ -276,13 +223,6 @@ h2 {
 	display: flex;
 	flex-direction: column;
 	gap: 2.5rem;
-}
-
-.home-hero {
-	display: flex;
-	align-items: center;
-	gap: 2.5rem;
-	flex-wrap: wrap;
 }
 
 .home-hero-text {
@@ -317,81 +257,13 @@ h2 {
 	max-width: 400px;
 }
 
-.home-cta-row {
-	display: flex;
-	gap: 12px;
-	flex-wrap: wrap;
-	margin-top: 0.25rem;
-}
-
-.home-cta-primary {
-	padding: 10px 20px;
-	background: #534ab7;
-	color: #fff;
-	border: none;
-	border-radius: 8px;
-	font-size: 14px;
-	font-weight: 500;
-	cursor: pointer;
-	transition: opacity 0.15s;
-}
-
-.home-cta-primary:hover {
-	opacity: 0.85;
-}
-
-.home-cta-secondary {
-	padding: 10px 20px;
-	background: transparent;
-	color: inherit;
-	border: 1px solid #ccc;
-	border-radius: 8px;
-	font-size: 14px;
-	font-weight: 500;
-	cursor: pointer;
-	transition: background 0.15s;
-}
-
-.home-cta-secondary:hover {
-	background: rgba(0, 0, 0, 0.05);
-}
-
 .home-pong-illustration {
 	flex-shrink: 0;
-}
-
-.home-info-cards {
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 12px;
-}
-
-.home-info-card {
-	border: 1px solid #e0e0e0;
-	border-radius: 12px;
-	padding: 1rem 1.25rem;
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-}
-
-.home-card-title {
-	font-size: 14px;
-	font-weight: 500;
-}
-
-.home-card-body {
-	font-size: 13px;
-	color: #666;
-	line-height: 1.6;
 }
 
 @media (max-width: 600px) {
 	.home-content {
 		padding: 1.5rem 1rem;
-	}
-	.home-info-cards {
-		grid-template-columns: 1fr;
 	}
 	.home-pong-illustration svg {
 		width: 100%;
@@ -410,22 +282,6 @@ h2 {
 .profile h2 {
 	color: #333;
 	margin-bottom: 30px;
-}
-
-.profile-content {
-	display: flex;
-	gap: 40px;
-	background: white;
-	padding: 30px;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.avatar-section {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 15px;
 }
 
 .avatar-large {
@@ -449,53 +305,6 @@ h2 {
 	font-weight: bold;
 }
 
-.avatar-actions {
-	display: flex;
-	gap: 10px;
-}
-
-.profile-info {
-	flex: 1;
-}
-
-.info-row {
-	margin-bottom: 20px;
-}
-
-.info-row .label {
-	display: block;
-	font-weight: bold;
-	color: #666;
-	margin-bottom: 5px;
-}
-
-.info-row .value {
-	display: block;
-	color: #333;
-	font-size: 1.1rem;
-}
-
-.info-row .value.bio {
-	white-space: pre-wrap;
-	line-height: 1.6;
-}
-
-/* ============================================ */
-/* プロフィール編集フォーム */
-/* ============================================ */
-
-.profile-edit {
-	max-width: 600px;
-	background: white;
-	padding: 30px;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.profile-edit h2 {
-	margin-bottom: 30px;
-}
-
 /* ============================================ */
 /* フレンドリスト */
 /* ============================================ */
@@ -505,40 +314,10 @@ h2 {
 	margin-bottom: 20px;
 }
 
-.add-friend-form {
-	display: flex;
-	gap: 10px;
-	margin-bottom: 30px;
-	background: white;
-	padding: 20px;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.add-friend-form input {
-	flex: 1;
-}
-
 .friends-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 	gap: 20px;
-}
-
-.friend-card {
-	background: white;
-	padding: 20px;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 15px;
-}
-
-.friend-actions {
-	display: flex;
-	gap: 10px;
 }
 
 .avatar {
@@ -571,14 +350,6 @@ h2 {
 	line-height: 1.4;
 }
 
-.empty-state {
-	text-align: center;
-	color: #999;
-	padding: 40px;
-	background: white;
-	border-radius: 10px;
-}
-
 /* ============================================ */
 /* フレンドリクエスト */
 /* ============================================ */
@@ -598,54 +369,16 @@ h2 {
 	margin-top: 0;
 }
 
-.request-list {
-	display: flex;
-	flex-direction: column;
-	gap: 15px;
-}
-
-.request-card {
-	background: white;
-	padding: 20px;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	display: flex;
-	align-items: center;
-	gap: 15px;
-}
-
-.request-info {
-	flex: 1;
-}
-
-.request-info h4 {
-	color: #333;
-	margin-bottom: 5px;
-}
-
-.request-actions {
-	display: flex;
-	gap: 10px;
-}
-
-.request-status {
-	padding: 8px 16px;
-}
-
-.status-badge {
-	padding: 6px 12px;
-	background: #e3f2fd;
-	color: #1976d2;
-	border-radius: 15px;
-	font-size: 0.85rem;
-	font-weight: bold;
-}
+/* ============================================ */
+/* ゲームページ */
+/* ============================================ */
 
 .game-page {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 }
+
 .game-header {
 	display: flex;
 	justify-content: space-between;
@@ -676,13 +409,12 @@ h2 {
 	padding: 16px;
 }
 
-/* canvas(700px) + gap(16px) + panel(260px) + padding(80px) + sidebar(250px) + AppPadding(40px) = 1346px */
-/* iPad Pro(1366px) > 1340px → 横並び ✓ */
 @media (max-width: 1340px) {
 	.game-layout {
 		grid-template-columns: 1fr;
 	}
 }
+
 /* Game settings slider layout */
 .game-side-panel label.slider-row {
 	display: grid;
@@ -693,7 +425,7 @@ h2 {
 }
 
 .game-side-panel .slider-label {
-	white-space: nowrap; /* ここで変な改行を止める */
+	white-space: nowrap;
 	font-weight: 600;
 }
 
@@ -742,18 +474,11 @@ h2 {
 	padding: 10px 15px;
 }
 
-.chat-room-list {
-	list-style: none;
-	flex: 1;
-	overflow-y: auto;
-	padding-left: 0;
-}
-
-.chat-room-list li {
+.chat-sidebar li {
 	margin-bottom: 5px;
 }
 
-.chat-room-list button {
+.chat-sidebar button {
 	width: 100%;
 	padding: 10px 15px;
 	background: transparent;
@@ -766,119 +491,13 @@ h2 {
 	transition: all 0.2s;
 }
 
-.chat-room-list button:hover {
+.chat-sidebar button:hover {
 	background: #e9ecef;
 }
 
-.chat-room-list button.active {
+.chat-sidebar button.active {
 	background: #667eea;
 	color: white;
-}
-
-.chat-new-room {
-	display: flex;
-	gap: 8px;
-	margin-top: 15px;
-	padding-top: 15px;
-	border-top: 1px solid #e0e0e0;
-}
-
-.chat-new-room input {
-	flex: 1;
-	padding: 8px;
-	font-size: 0.9rem;
-}
-
-.chat-new-room button {
-	padding: 8px 12px;
-	background: #667eea;
-	color: white;
-	border: none;
-	border-radius: 5px;
-	cursor: pointer;
-	font-size: 1rem;
-}
-
-.chat-new-room button:hover {
-	background: #5568d3;
-}
-
-.chat-main {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-}
-
-.chat-placeholder {
-	flex: 1;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: #999;
-	font-size: 1.1rem;
-}
-
-/* ============================================ */
-/* チャットルーム */
-/* ============================================ */
-
-.chat-room {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-}
-
-.chat-room-header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 15px 20px;
-	border-bottom: 1px solid #e0e0e0;
-	background: #fff;
-}
-
-.chat-room-header h3 {
-	color: #333;
-	font-size: 1.1rem;
-}
-
-.chat-status {
-	font-size: 0.85rem;
-	color: #999;
-}
-
-.chat-status.connected {
-	color: #28a745;
-}
-
-.chat-messages {
-	flex: 1;
-	overflow-y: auto;
-	padding: 20px;
-	background: #f8f9fa;
-}
-
-.chat-empty {
-	text-align: center;
-	color: #999;
-	padding: 40px;
-}
-
-.chat-input-area {
-	display: flex;
-	gap: 10px;
-	padding: 15px 20px;
-	border-top: 1px solid #e0e0e0;
-	background: #fff;
-}
-
-.chat-input {
-	flex: 1;
-	font-size: 1rem;
-}
-
-.chat-input:disabled {
-	background: #f0f0f0;
 }
 
 /* ============================================ */
@@ -940,6 +559,28 @@ h2 {
 }
 
 /* ============================================ */
+/* チャット接続ステータス */
+/* ============================================ */
+
+.chat-status {
+	font-size: 0.85rem;
+	color: #999;
+}
+
+.chat-status.connected {
+	color: #28a745;
+}
+
+.chat-input {
+	flex: 1;
+	font-size: 1rem;
+}
+
+.chat-input:disabled {
+	background: #f0f0f0;
+}
+
+/* ============================================ */
 /* オンライン対戦ページ */
 /* ============================================ */
 
@@ -958,26 +599,6 @@ h2 {
 	grid-template-columns: 1fr 1fr;
 	gap: 20px;
 	margin-bottom: 30px;
-}
-
-.online-card {
-	background: white;
-	padding: 30px;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.online-card h3 {
-	color: #333;
-	margin-bottom: 20px;
-	font-size: 1.1rem;
-}
-
-.online-status-row {
-	display: flex;
-	align-items: center;
-	gap: 15px;
-	margin-bottom: 20px;
 }
 
 .online-pill {
@@ -1019,36 +640,6 @@ h2 {
 	font-size: 0.9rem;
 }
 
-.online-desc {
-	margin-bottom: 25px;
-	color: #555;
-	line-height: 1.6;
-}
-
-.online-desc p {
-	margin: 0;
-}
-
-.online-actions {
-	display: flex;
-	gap: 10px;
-}
-
-.online-message {
-	margin-top: 15px;
-	padding: 10px 15px;
-	background: #fff3cd;
-	border-radius: 5px;
-	color: #856404;
-	font-size: 0.9rem;
-}
-
-.online-hr {
-	margin: 30px 0 20px;
-	border: none;
-	border-top: 1px solid #e0e0e0;
-}
-
 .online-connection-status {
 	display: flex;
 	align-items: center;
@@ -1070,7 +661,6 @@ h2 {
 	background: #e74c3c;
 }
 
-/* レスポンシブ対応 */
 @media (max-width: 768px) {
 	.online-layout {
 		grid-template-columns: 1fr;
@@ -1078,34 +668,10 @@ h2 {
 }
 
 /* ============================================ */
-/* フッター（法的ページリンク）                 */
+/* フッターリンクボタン */
 /* ============================================ */
 
-.app-footer {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 10px 20px;
-	border-top: 1px solid #e0e0e0;
-	background: #f8f9fa;
-	font-size: 0.75rem;
-	color: #999;
-	flex-shrink: 0;
-}
-
-.unified-container.logged-out .app-footer {
-	border-top: 1px solid #e9ecef;
-	background: transparent;
-	margin-top: 20px;
-	padding: 10px 0 0;
-}
-
-.app-footer-links {
-	display: flex;
-	gap: 12px;
-}
-
-.app-footer-links button {
+footer .d-flex button {
 	background: none;
 	border: none;
 	color: #667eea;
@@ -1116,7 +682,7 @@ h2 {
 	transition: color 0.2s;
 }
 
-.app-footer-links button:hover {
+footer .d-flex button:hover {
 	color: #764ba2;
 }
 
@@ -1124,19 +690,16 @@ h2 {
 /* 法的ページ モーダル                          */
 /* ============================================ */
 
-/* legal-overlay, legal-modal は Bootstrap modal に移行済み */
-
-/* Bootstrap モーダルの背景オーバーレイ */
 .modal.d-block {
 	background: rgba(0, 0, 0, 0.5);
 }
 
-/* legal-modal-header のグラデーション背景のみ維持 */
 .legal-modal-header {
 	background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
 	border-bottom: none !important;
 }
 
+/* ============================================ */
 /* 42 OAuthログインボタン */
 /* ============================================ */
 
@@ -1201,36 +764,6 @@ h2 {
 /* 2FA設定（プロフィール内） */
 /* ============================================ */
 
-.twofa-settings {
-	margin-top: 30px;
-	padding: 25px 30px;
-	background: white;
-	border-radius: 10px;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	text-align: center;
-}
-
-.twofa-settings h3 {
-	color: #333;
-	margin-bottom: 10px;
-	font-size: 1.1rem;
-}
-
-.twofa-settings > p {
-	margin-bottom: 20px;
-	color: #555;
-	font-size: 0.95rem;
-}
-
-.twofa-status {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	font-size: 0.95rem;
-	color: #555;
-}
-
 .twofa-status-dot {
 	width: 10px;
 	height: 10px;
@@ -1243,10 +776,6 @@ h2 {
 
 .twofa-status-dot.disabled {
 	background: #e74c3c;
-}
-
-.twofa-setup {
-	margin-top: 10px;
 }
 
 .twofa-setup p {
@@ -1263,14 +792,6 @@ h2 {
 	border-radius: 10px;
 	padding: 8px;
 	background: white;
-}
-
-.twofa-setup form {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	gap: 10px;
-	margin-top: 15px;
 }
 
 .twofa-setup input {
@@ -1292,13 +813,4 @@ h2 {
 
 .twofa-cancel:hover {
 	color: #667eea;
-}
-
-.twofa-settings .btn {
-	margin-top: 5px;
-}
-
-.twofa-settings .message {
-	margin-top: 15px;
-	font-size: 0.9rem;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -212,11 +212,149 @@ function App() {
 		switch (currentPage) {
 			case "home":
 				return (
-					<div className="home">
-						<h2>{t("home.welcome", { username: user.username })}</h2>
-						<p>
-							{t("home.userId")}: {user.id}
-						</p>
+					<div className="home-content">
+						{/* ヒーローセクション */}
+						<div className="home-hero">
+							<div className="home-hero-text">
+								<p className="home-welcome-label">{t("home.welcomeLabel")}</p>
+								<h2 className="home-welcome-name">
+									{t("home.hello")}、
+									<span className="home-username">{user.username}</span>
+									{t("home.san")}
+								</h2>
+								<p className="home-desc">{t("home.description")}</p>
+								<div className="home-cta-row">
+									<button
+										type="button"
+										className="home-cta-primary"
+										onClick={() => {
+											setGameRoomId(null);
+											setGameOpponent(null);
+											navigateTo("online");
+										}}
+									>
+										{t("home.ctaOnline")}
+									</button>
+									<button
+										type="button"
+										className="home-cta-secondary"
+										onClick={() => {
+											setGameRoomId(null);
+											setGameOpponent(null);
+											navigateTo("game");
+										}}
+									>
+										{t("home.ctaAi")}
+									</button>
+								</div>
+							</div>
+
+							{/* Pongコートイラスト */}
+							<div className="home-pong-illustration">
+								<svg
+									width="300"
+									height="200"
+									viewBox="0 0 300 200"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<rect width="300" height="200" rx="12" fill="#1a1a2e" />
+									<line
+										x1="150"
+										y1="10"
+										x2="150"
+										y2="190"
+										stroke="#ffffff"
+										strokeWidth="2"
+										strokeDasharray="8 6"
+										opacity="0.3"
+									/>
+									<rect
+										x="16"
+										y="70"
+										width="10"
+										height="60"
+										rx="5"
+										fill="#AFA9EC"
+									/>
+									<rect
+										x="274"
+										y="70"
+										width="10"
+										height="60"
+										rx="5"
+										fill="#AFA9EC"
+									/>
+									<circle cx="150" cy="100" r="8" fill="white" />
+									<circle
+										cx="150"
+										cy="100"
+										r="18"
+										fill="none"
+										stroke="white"
+										strokeWidth="0.5"
+										opacity="0.15"
+									/>
+									<circle
+										cx="150"
+										cy="100"
+										r="32"
+										fill="none"
+										stroke="white"
+										strokeWidth="0.5"
+										opacity="0.08"
+									/>
+									<text
+										x="75"
+										y="30"
+										textAnchor="middle"
+										fill="#AFA9EC"
+										fontSize="18"
+										fontWeight="bold"
+										fontFamily="monospace"
+									>
+										3
+									</text>
+									<text
+										x="225"
+										y="30"
+										textAnchor="middle"
+										fill="#AFA9EC"
+										fontSize="18"
+										fontWeight="bold"
+										fontFamily="monospace"
+									>
+										5
+									</text>
+									<rect
+										x="10"
+										y="10"
+										width="280"
+										height="180"
+										rx="10"
+										fill="none"
+										stroke="#AFA9EC"
+										strokeWidth="1.5"
+										opacity="0.4"
+									/>
+								</svg>
+							</div>
+						</div>
+
+						{/* インフォカード */}
+						<div className="home-info-cards">
+							<div className="home-info-card">
+								<p className="home-card-title">{t("home.cardOnlineTitle")}</p>
+								<p className="home-card-body">{t("home.cardOnlineDesc")}</p>
+							</div>
+							<div className="home-info-card">
+								<p className="home-card-title">{t("home.cardAiTitle")}</p>
+								<p className="home-card-body">{t("home.cardAiDesc")}</p>
+							</div>
+							<div className="home-info-card">
+								<p className="home-card-title">{t("home.cardRankTitle")}</p>
+								<p className="home-card-body">{t("home.cardRankDesc")}</p>
+							</div>
+						</div>
 					</div>
 				);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -214,7 +214,7 @@ function App() {
 				return (
 					<div className="home-content">
 						{/* ヒーローセクション */}
-						<div className="home-hero">
+						<div className="d-flex align-items-center gap-5 flex-wrap">
 							<div className="home-hero-text">
 								<p className="home-welcome-label">{t("home.welcomeLabel")}</p>
 								<h2 className="home-welcome-name">
@@ -223,10 +223,10 @@ function App() {
 									{t("home.san")}
 								</h2>
 								<p className="home-desc">{t("home.description")}</p>
-								<div className="home-cta-row">
+								<div className="d-flex gap-3 flex-wrap mt-1">
 									<button
 										type="button"
-										className="home-cta-primary"
+										className="btn btn-primary"
 										onClick={() => {
 											setGameRoomId(null);
 											setGameOpponent(null);
@@ -237,7 +237,7 @@ function App() {
 									</button>
 									<button
 										type="button"
-										className="home-cta-secondary"
+										className="btn btn-outline-secondary"
 										onClick={() => {
 											setGameRoomId(null);
 											setGameOpponent(null);
@@ -341,18 +341,45 @@ function App() {
 						</div>
 
 						{/* インフォカード */}
-						<div className="home-info-cards">
-							<div className="home-info-card">
-								<p className="home-card-title">{t("home.cardOnlineTitle")}</p>
-								<p className="home-card-body">{t("home.cardOnlineDesc")}</p>
+						<div className="row g-3">
+							<div className="col-12 col-md-4">
+								<div className="border rounded-3 p-3 d-flex flex-column gap-1 h-100">
+									<p className="fw-medium small mb-0">
+										{t("home.cardOnlineTitle")}
+									</p>
+									<p
+										className="text-muted small mb-0"
+										style={{ lineHeight: 1.6 }}
+									>
+										{t("home.cardOnlineDesc")}
+									</p>
+								</div>
 							</div>
-							<div className="home-info-card">
-								<p className="home-card-title">{t("home.cardAiTitle")}</p>
-								<p className="home-card-body">{t("home.cardAiDesc")}</p>
+							<div className="col-12 col-md-4">
+								<div className="border rounded-3 p-3 d-flex flex-column gap-1 h-100">
+									<p className="fw-medium small mb-0">
+										{t("home.cardAiTitle")}
+									</p>
+									<p
+										className="text-muted small mb-0"
+										style={{ lineHeight: 1.6 }}
+									>
+										{t("home.cardAiDesc")}
+									</p>
+								</div>
 							</div>
-							<div className="home-info-card">
-								<p className="home-card-title">{t("home.cardRankTitle")}</p>
-								<p className="home-card-body">{t("home.cardRankDesc")}</p>
+							<div className="col-12 col-md-4">
+								<div className="border rounded-3 p-3 d-flex flex-column gap-1 h-100">
+									<p className="fw-medium small mb-0">
+										{t("home.cardRankTitle")}
+									</p>
+									<p
+										className="text-muted small mb-0"
+										style={{ lineHeight: 1.6 }}
+									>
+										{t("home.cardRankDesc")}
+									</p>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -477,13 +504,13 @@ function App() {
 							onClick={() => setMenuOpen(false)}
 						/>
 						<nav className={`sidebar ${menuOpen ? "open" : ""}`}>
-							<div className="sidebar-header">
-								<h1>ft_transcendence</h1>
+							<div className="mb-5">
+								<h1 className="mb-2">ft_transcendence</h1>
 								<button className="lang-toggle" onClick={cycleLanguage}>
 									{LANGUAGE_LABELS[i18n.language] || "EN"}
 								</button>
 							</div>
-							<ul className="nav-menu">
+							<ul className="list-unstyled flex-grow-1 ps-0">
 								<li>
 									<button
 										className={currentPage === "home" ? "active" : ""}
@@ -588,7 +615,7 @@ function App() {
 								</li>
 							</ul>
 
-							<div className="sidebar-footer">
+							<div className="mt-auto">
 								<button onClick={handleLogout} className="btn btn-danger w-100">
 									{t("nav.logout")}
 								</button>
@@ -596,10 +623,15 @@ function App() {
 						</nav>
 
 						<main className="main-content">
-							<div className="main-content-inner">{renderContent()}</div>
-							<footer className="app-footer">
-								<span>{t("legal.footer.rights")}</span>
-								<div className="app-footer-links">
+							<div className="flex-grow-1 p-5 overflow-auto">
+								{renderContent()}
+							</div>
+							<footer
+								className="d-flex justify-content-between align-items-center px-4 py-2 border-top bg-light flex-shrink-0"
+								style={{ fontSize: "0.75rem" }}
+							>
+								<span className="text-muted">{t("legal.footer.rights")}</span>
+								<div className="d-flex gap-3">
 									<button onClick={() => setLegalModal("privacy")}>
 										{t("legal.footer.privacy")}
 									</button>
@@ -619,8 +651,8 @@ function App() {
 							/>
 						) : (
 							<div className="auth-content">
-								<div className="auth-header">
-									<h1>ft_transcendence</h1>
+								<div className="text-center mb-5">
+									<h1 className="mb-2">ft_transcendence</h1>
 									<button className="lang-toggle" onClick={cycleLanguage}>
 										{LANGUAGE_LABELS[i18n.language] || "EN"}
 									</button>
@@ -688,9 +720,12 @@ function App() {
 								</div>
 							</div>
 						)}
-						<footer className="app-footer">
-							<span>{t("legal.footer.rights")}</span>
-							<div className="app-footer-links">
+						<footer
+							className="d-flex justify-content-between align-items-center border-top mt-4 pt-3"
+							style={{ fontSize: "0.75rem" }}
+						>
+							<span className="text-muted">{t("legal.footer.rights")}</span>
+							<div className="d-flex gap-3">
 								<button onClick={() => setLegalModal("privacy")}>
 									{t("legal.footer.privacy")}
 								</button>

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -71,7 +71,7 @@ export default function ChatPage({
 		<div className="chat-page">
 			<div className="chat-sidebar">
 				<h3>{t("chat.rooms")}</h3>
-				<ul className="chat-room-list">
+				<ul className="list-unstyled flex-grow-1 overflow-auto ps-0">
 					{rooms.map((room) => (
 						<li key={room}>
 							<button
@@ -86,7 +86,7 @@ export default function ChatPage({
 				</ul>
 
 				<h3 className="chat-section-title">{t("chat.dms")}</h3>
-				<ul className="chat-room-list">
+				<ul className="list-unstyled flex-grow-1 overflow-auto ps-0">
 					{dmRooms.length > 0 ? (
 						dmRooms.map((dm) => (
 							<li key={dm.roomId}>
@@ -105,7 +105,7 @@ export default function ChatPage({
 				</ul>
 			</div>
 
-			<div className="chat-main">
+			<div className="flex-grow-1 d-flex flex-column">
 				{currentRoomId ? (
 					<ChatRoom
 						roomId={currentRoomId}
@@ -115,7 +115,7 @@ export default function ChatPage({
 						}
 					/>
 				) : (
-					<div className="chat-placeholder">
+					<div className="flex-grow-1 d-flex align-items-center justify-content-center text-muted fs-5">
 						<p>{t("chat.selectRoom")}</p>
 					</div>
 				)}

--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -125,8 +125,8 @@ export default function ChatRoom({
 	};
 
 	return (
-		<div className="chat-room">
-			<div className="chat-room-header">
+		<div className="d-flex flex-column h-100">
+			<div className="d-flex align-items-center justify-content-between px-4 py-3 border-bottom bg-white">
 				<h3>{displayName ? `@ ${displayName}` : `# ${roomId}`}</h3>
 				<span className={`chat-status ${isConnected ? "connected" : ""}`}>
 					{isConnected
@@ -135,9 +135,9 @@ export default function ChatRoom({
 				</span>
 			</div>
 
-			<div className="chat-messages">
+			<div className="flex-grow-1 overflow-auto p-4 bg-light">
 				{messages.length === 0 ? (
-					<p className="chat-empty">{t("chat.noMessages")}</p>
+					<p className="text-center text-muted p-5">{t("chat.noMessages")}</p>
 				) : (
 					messages.map((msg, index) => (
 						<ChatMessage
@@ -150,7 +150,7 @@ export default function ChatRoom({
 				<div ref={messagesEndRef} />
 			</div>
 
-			<div className="chat-input-area">
+			<div className="d-flex gap-2 px-4 py-3 border-top bg-white">
 				<input
 					type="text"
 					className="form-control rounded-pill chat-input"

--- a/frontend/src/components/FriendList.tsx
+++ b/frontend/src/components/FriendList.tsx
@@ -85,7 +85,10 @@ const FriendList: React.FC<FriendListProps> = ({ onStartDM }) => {
 			</h2>
 
 			{/* フレンド追加フォーム */}
-			<form onSubmit={handleSendRequest} className="add-friend-form">
+			<form
+				onSubmit={handleSendRequest}
+				className="d-flex gap-3 mb-5 p-4 bg-white rounded-3 shadow-sm"
+			>
 				<input
 					className="form-control"
 					type="text"
@@ -103,11 +106,16 @@ const FriendList: React.FC<FriendListProps> = ({ onStartDM }) => {
 
 			{/* フレンドリスト */}
 			{friends.length === 0 ? (
-				<p className="empty-state">{t("friends.noFriends")}</p>
+				<p className="text-center text-muted p-5 bg-white rounded-3">
+					{t("friends.noFriends")}
+				</p>
 			) : (
 				<div className="friends-grid">
 					{friends.map((friendItem) => (
-						<div key={friendItem.id} className="friend-card">
+						<div
+							key={friendItem.id}
+							className="bg-white p-4 rounded-3 shadow-sm d-flex flex-column align-items-center gap-3"
+						>
 							{friendItem.friend.avatarUrl ? (
 								<img
 									src={friendItem.friend.avatarUrl}
@@ -128,7 +136,7 @@ const FriendList: React.FC<FriendListProps> = ({ onStartDM }) => {
 									<p className="bio">{friendItem.friend.bio}</p>
 								)}
 							</div>
-							<div className="friend-actions">
+							<div className="d-flex gap-2">
 								{onStartDM && (
 									<button
 										onClick={() =>

--- a/frontend/src/components/FriendRequests.tsx
+++ b/frontend/src/components/FriendRequests.tsx
@@ -91,11 +91,16 @@ const FriendRequests: React.FC = () => {
 					{t("friendRequests.received")} ({requests.received.length})
 				</h3>
 				{requests.received.length === 0 ? (
-					<p className="empty-state">{t("friendRequests.noRequests")}</p>
+					<p className="text-center text-muted p-5 bg-white rounded-3">
+						{t("friendRequests.noRequests")}
+					</p>
 				) : (
-					<div className="request-list">
+					<div className="d-flex flex-column gap-3">
 						{requests.received.map((request) => (
-							<div key={request.id} className="request-card">
+							<div
+								key={request.id}
+								className="bg-white p-4 rounded-3 shadow-sm d-flex align-items-center gap-3"
+							>
 								{request.sender.avatarUrl ? (
 									<img
 										src={request.sender.avatarUrl}
@@ -107,7 +112,7 @@ const FriendRequests: React.FC = () => {
 										{request.sender.username.charAt(0).toUpperCase()}
 									</div>
 								)}
-								<div className="request-info">
+								<div className="flex-grow-1">
 									<h4>
 										{request.sender.displayName || request.sender.username}
 									</h4>
@@ -116,7 +121,7 @@ const FriendRequests: React.FC = () => {
 										<p className="bio">{request.sender.bio}</p>
 									)}
 								</div>
-								<div className="request-actions">
+								<div className="d-flex gap-2">
 									<button
 										onClick={() => handleAccept(request.id)}
 										className="btn btn-primary btn-sm"
@@ -144,11 +149,16 @@ const FriendRequests: React.FC = () => {
 					{t("friendRequests.sent")} ({requests.sent.length})
 				</h3>
 				{requests.sent.length === 0 ? (
-					<p className="empty-state">{t("friendRequests.noRequests")}</p>
+					<p className="text-center text-muted p-5 bg-white rounded-3">
+						{t("friendRequests.noRequests")}
+					</p>
 				) : (
-					<div className="request-list">
+					<div className="d-flex flex-column gap-3">
 						{requests.sent.map((request) => (
-							<div key={request.id} className="request-card">
+							<div
+								key={request.id}
+								className="bg-white p-4 rounded-3 shadow-sm d-flex align-items-center gap-3"
+							>
 								{request.receiver.avatarUrl ? (
 									<img
 										src={request.receiver.avatarUrl}
@@ -160,7 +170,7 @@ const FriendRequests: React.FC = () => {
 										{request.receiver.username.charAt(0).toUpperCase()}
 									</div>
 								)}
-								<div className="request-info">
+								<div className="flex-grow-1">
 									<h4>
 										{request.receiver.displayName || request.receiver.username}
 									</h4>
@@ -170,7 +180,7 @@ const FriendRequests: React.FC = () => {
 									)}
 								</div>
 								<div className="request-status">
-									<span className="status-badge">
+									<span className="badge rounded-pill bg-info bg-opacity-25 text-primary">
 										{t("friendRequests.sentStatus")}
 									</span>
 								</div>

--- a/frontend/src/components/FriendRequests.tsx
+++ b/frontend/src/components/FriendRequests.tsx
@@ -179,7 +179,7 @@ const FriendRequests: React.FC = () => {
 										<p className="bio">{request.receiver.bio}</p>
 									)}
 								</div>
-								<div className="request-status">
+								<div>
 									<span className="badge rounded-pill bg-info bg-opacity-25 text-primary">
 										{t("friendRequests.sentStatus")}
 									</span>

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -169,7 +169,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 					{subtitle && <p className="game-subtitle">{subtitle}</p>}
 				</div>
 
-				<div style={{ display: "flex", gap: 8 }}>
+				<div className="d-flex gap-2">
 					{!gameResult && gameState && (
 						<button
 							type="button"
@@ -204,19 +204,16 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 					{/* 一時停止オーバーレイ */}
 					{isPaused && (
 						<div
+							className="position-absolute top-50 start-50 translate-middle text-center rounded-3"
 							style={{
-								position: "absolute",
-								top: "50%",
-								left: "50%",
-								transform: "translate(-50%, -50%)",
 								background: "rgba(0,0,0,0.8)",
 								padding: "24px 40px",
-								borderRadius: "16px",
-								textAlign: "center",
 								zIndex: 10,
 							}}
 						>
-							<h3 style={{ color: "#ffaa00", margin: 0 }}>{pauseMessage}</h3>
+							<h3 className="m-0" style={{ color: "#ffaa00" }}>
+								{pauseMessage}
+							</h3>
 							<p style={{ color: "#aaa", marginTop: 8 }}>
 								{t("game.waitingForReconnect")}
 							</p>
@@ -226,22 +223,17 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 					{/* ゲーム結果表示 */}
 					{gameResult && (
 						<div
+							className="position-absolute top-50 start-50 translate-middle text-center rounded-3"
 							style={{
-								position: "absolute",
-								top: "50%",
-								left: "50%",
-								transform: "translate(-50%, -50%)",
 								background: "rgba(0,0,0,0.9)",
 								padding: "32px 48px",
-								borderRadius: "16px",
-								textAlign: "center",
 								zIndex: 10,
 							}}
 						>
 							<h2
+								className="m-0"
 								style={{
 									color: gameResult.isWinner ? "#00ff88" : "#ff4444",
-									margin: 0,
 								}}
 							>
 								{gameResult.isWinner ? t("game.youWin") : t("game.youLose")}
@@ -257,7 +249,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 							<button
 								type="button"
 								onClick={handleBackToOnline}
-								style={{ marginTop: 16 }}
+								className="btn btn-secondary mt-3"
 							>
 								{mode === "ai" ? t("game.playAgain") : t("game.backToOnline")}
 							</button>
@@ -267,7 +259,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 
 				<aside className="game-side-panel">
 					<h3>{t("game.controls")}</h3>
-					<p style={{ marginTop: 0 }}>
+					<p className="mt-0">
 						<code>↑ W</code> / <code>↓ S</code>
 					</p>
 				</aside>

--- a/frontend/src/components/GdprSettings.module.css
+++ b/frontend/src/components/GdprSettings.module.css
@@ -1,129 +1,8 @@
 .container {
-	padding: var(--space-6, 24px);
+	padding: 24px;
 	max-width: 640px;
 	margin: 0 auto;
 }
-
-.title {
-	font-size: 1.5rem;
-	font-weight: 700;
-	color: #333;
-	margin-bottom: var(--space-6, 24px);
-	text-align: left;
-}
-
-/* ============================================ */
-/* セクション */
-/* ============================================ */
-
-.section {
-	display: flex;
-	justify-content: space-between;
-	align-items: flex-start;
-	gap: var(--space-6, 24px);
-	padding: var(--space-5, 20px) 0;
-}
-
-.sectionHeader {
-	flex: 1;
-}
-
-.sectionTitle {
-	font-size: 1rem;
-	font-weight: 600;
-	color: #333;
-	margin: 0 0 8px;
-}
-
-.dangerTitle {
-	color: #e74c3c;
-}
-
-.sectionDesc {
-	font-size: 0.875rem;
-	color: #666;
-	line-height: 1.6;
-	margin: 0;
-}
-
-.sectionAction {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-end;
-	gap: 8px;
-	flex-shrink: 0;
-}
-
-.divider {
-	border: none;
-	border-top: 1px solid #e9ecef;
-	margin: 0;
-}
-
-/* ============================================ */
-/* ボタン */
-/* ============================================ */
-
-.btnSecondary {
-	padding: 8px 20px;
-	border-radius: 6px;
-	border: 1px solid #6c757d;
-	background: white;
-	color: #6c757d;
-	font-size: 0.875rem;
-	font-weight: 500;
-	cursor: pointer;
-	transition:
-		background 0.2s,
-		color 0.2s;
-	white-space: nowrap;
-}
-
-.btnSecondary:hover:not(:disabled) {
-	background: #6c757d;
-	color: white;
-}
-
-.btnSecondary:disabled {
-	opacity: 0.6;
-	cursor: not-allowed;
-}
-
-.btnDanger {
-	padding: 8px 20px;
-	border-radius: 6px;
-	border: none;
-	background: #e74c3c;
-	color: white;
-	font-size: 0.875rem;
-	font-weight: 500;
-	cursor: pointer;
-	transition: background 0.2s;
-	white-space: nowrap;
-}
-
-.btnDanger:hover:not(:disabled) {
-	background: #c0392b;
-}
-
-.btnDanger:disabled {
-	opacity: 0.6;
-	cursor: not-allowed;
-}
-
-/* ============================================ */
-/* エラーテキスト */
-/* ============================================ */
-
-.errorText {
-	font-size: 0.8rem;
-	color: #e74c3c;
-	margin: 0;
-}
-
-/* ============================================ */
-/* 確認ダイアログ */
-/* ============================================ */
 
 .overlay {
 	position: fixed;
@@ -133,36 +12,7 @@
 	align-items: center;
 	justify-content: center;
 	z-index: 1000;
-	padding: var(--space-4, 16px);
-}
-
-.dialog {
-	background: white;
-	border-radius: 12px;
-	padding: var(--space-6, 24px);
-	max-width: 420px;
-	width: 100%;
-	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-}
-
-.dialogTitle {
-	font-size: 1.1rem;
-	font-weight: 700;
-	color: #333;
-	margin: 0 0 12px;
-}
-
-.dialogDesc {
-	font-size: 0.875rem;
-	color: #666;
-	line-height: 1.6;
-	margin: 0 0 20px;
-}
-
-.dialogActions {
-	display: flex;
-	justify-content: flex-end;
-	gap: 10px;
+	padding: 16px;
 }
 
 /* ============================================ */
@@ -170,17 +20,16 @@
 /* ============================================ */
 
 @media (max-width: 600px) {
-	.section {
+	.container section {
 		flex-direction: column;
 	}
 
-	.sectionAction {
+	.container section > div:last-child {
 		align-items: flex-start;
 		width: 100%;
 	}
 
-	.btnSecondary,
-	.btnDanger {
+	.container section > div:last-child .btn {
 		width: 100%;
 	}
 }

--- a/frontend/src/components/GdprSettings.tsx
+++ b/frontend/src/components/GdprSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useGdpr } from "../hooks/useGdpr";
 import styles from "./GdprSettings.module.css";
@@ -44,39 +44,45 @@ export default function GdprSettings({
 
 	return (
 		<div className={styles.container}>
-			<h2 className={styles.title}>{t("gdpr.title")}</h2>
+			<h2 className="fs-4 fw-bold text-dark mb-4 text-start">
+				{t("gdpr.title")}
+			</h2>
 
 			{/* データエクスポート */}
-			<section className={styles.section}>
-				<div className={styles.sectionHeader}>
-					<h3 className={styles.sectionTitle}>{t("gdpr.exportTitle")}</h3>
-					<p className={styles.sectionDesc}>{t("gdpr.exportDesc")}</p>
+			<section className="d-flex justify-content-between align-items-start gap-4 py-4">
+				<div className="flex-grow-1">
+					<h3 className="fs-6 fw-semibold text-dark mb-2">
+						{t("gdpr.exportTitle")}
+					</h3>
+					<p className="small text-muted lh-lg mb-0">{t("gdpr.exportDesc")}</p>
 				</div>
-				<div className={styles.sectionAction}>
+				<div className="d-flex flex-column align-items-end gap-2 flex-shrink-0">
 					<button
-						className={styles.btnSecondary}
+						className="btn btn-outline-secondary btn-sm text-nowrap"
 						onClick={handleExport}
 						disabled={exporting}
 					>
 						{exporting ? t("gdpr.exporting") : t("gdpr.download")}
 					</button>
-					{exportError && <p className={styles.errorText}>{exportError}</p>}
+					{exportError && (
+						<p className="small text-danger mb-0">{exportError}</p>
+					)}
 				</div>
 			</section>
 
-			<hr className={styles.divider} />
+			<hr className="m-0" />
 
 			{/* アカウント削除 */}
-			<section className={styles.section}>
-				<div className={styles.sectionHeader}>
-					<h3 className={`${styles.sectionTitle} ${styles.dangerTitle}`}>
+			<section className="d-flex justify-content-between align-items-start gap-4 py-4">
+				<div className="flex-grow-1">
+					<h3 className="fs-6 fw-semibold text-danger mb-2">
 						{t("gdpr.deleteTitle")}
 					</h3>
-					<p className={styles.sectionDesc}>{t("gdpr.deleteDesc")}</p>
+					<p className="small text-muted lh-lg mb-0">{t("gdpr.deleteDesc")}</p>
 				</div>
-				<div className={styles.sectionAction}>
+				<div className="d-flex flex-column align-items-end gap-2 flex-shrink-0">
 					<button
-						className={styles.btnDanger}
+						className="btn btn-danger btn-sm text-nowrap"
 						onClick={() => setShowConfirm(true)}
 					>
 						{t("gdpr.deleteButton")}
@@ -87,13 +93,22 @@ export default function GdprSettings({
 			{/* 削除確認ダイアログ */}
 			{showConfirm && (
 				<div className={styles.overlay} role="dialog" aria-modal="true">
-					<div className={styles.dialog}>
-						<h3 className={styles.dialogTitle}>{t("gdpr.confirmTitle")}</h3>
-						<p className={styles.dialogDesc}>{t("gdpr.confirmDesc")}</p>
-						{deleteError && <p className={styles.errorText}>{deleteError}</p>}
-						<div className={styles.dialogActions}>
+					<div
+						className="bg-white rounded-3 p-4 shadow-lg w-100"
+						style={{ maxWidth: 420 }}
+					>
+						<h3 className="fs-5 fw-bold text-dark mb-3">
+							{t("gdpr.confirmTitle")}
+						</h3>
+						<p className="small text-muted lh-lg mb-4">
+							{t("gdpr.confirmDesc")}
+						</p>
+						{deleteError && (
+							<p className="small text-danger mb-3">{deleteError}</p>
+						)}
+						<div className="d-flex justify-content-end gap-2">
 							<button
-								className={styles.btnSecondary}
+								className="btn btn-outline-secondary btn-sm"
 								onClick={() => {
 									setShowConfirm(false);
 									setDeleteError(null);
@@ -103,7 +118,7 @@ export default function GdprSettings({
 								{t("common.cancel")}
 							</button>
 							<button
-								className={styles.btnDanger}
+								className="btn btn-danger btn-sm"
 								onClick={handleDeleteConfirm}
 								disabled={deleting}
 							>

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -11,11 +11,11 @@ export default function HistoryPage() {
 	const { history, loading, error } = useStats();
 
 	if (loading) {
-		return <div style={{ padding: 24 }}>{t("common.loading")}</div>;
+		return <div className="p-4">{t("common.loading")}</div>;
 	}
 
 	if (error) {
-		return <div style={{ padding: 24 }}>{t(error)}</div>;
+		return <div className="p-4">{t(error)}</div>;
 	}
 
 	return (
@@ -50,7 +50,9 @@ export default function HistoryPage() {
 												: t("history.lose")}
 										</span>
 									</td>
-									<td>{m.myScore}-{m.opponentScore}</td>
+									<td>
+										{m.myScore}-{m.opponentScore}
+									</td>
 								</tr>
 							))}
 						</tbody>

--- a/frontend/src/components/LeaderboardPage.tsx
+++ b/frontend/src/components/LeaderboardPage.tsx
@@ -12,11 +12,11 @@ export default function LeaderboardPage() {
 	const { leaderboard, loading, error } = useLeaderboard();
 
 	if (loading) {
-		return <div style={{ padding: 24 }}>{t("common.loading")}</div>;
+		return <div className="p-4">{t("common.loading")}</div>;
 	}
 
 	if (error) {
-		return <div style={{ padding: 24 }}>{t(error)}</div>;
+		return <div className="p-4">{t(error)}</div>;
 	}
 
 	return (

--- a/frontend/src/components/OnlinePage.tsx
+++ b/frontend/src/components/OnlinePage.tsx
@@ -96,10 +96,10 @@ export default function OnlinePage({ onStart }: OnlinePageProps) {
 	return (
 		<div className="online-page">
 			<div className="online-layout">
-				<section className="online-card">
+				<section className="bg-white p-5 rounded-3 shadow-sm">
 					<h3>{t("online.status")}</h3>
 
-					<div className="online-status-row">
+					<div className="d-flex align-items-center gap-3 mb-4">
 						<span className={`online-pill ${status}`}>
 							{status.toUpperCase()}
 						</span>
@@ -113,7 +113,7 @@ export default function OnlinePage({ onStart }: OnlinePageProps) {
 						</div>
 					</div>
 
-					<div className="online-actions">
+					<div className="d-flex gap-2">
 						{status === "idle" && (
 							<button
 								type="button"
@@ -152,7 +152,11 @@ export default function OnlinePage({ onStart }: OnlinePageProps) {
 						)}
 					</div>
 
-					{message && <p className="online-message">{message}</p>}
+					{message && (
+						<p className="mt-3 px-3 py-2 bg-warning bg-opacity-25 rounded text-dark small">
+							{message}
+						</p>
+					)}
 				</section>
 			</div>
 		</div>

--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -96,9 +96,9 @@ const Profile: React.FC<ProfileProps> = ({
 		<div className="profile">
 			<h2>{t("profile.title")}</h2>
 
-			<div className="profile-content">
+			<div className="d-flex gap-5 bg-white p-5 rounded-3 shadow-sm">
 				{/* アバター表示 */}
-				<div className="avatar-section">
+				<div className="d-flex flex-column align-items-center gap-3">
 					{profile.avatarUrl ? (
 						<img
 							src={profile.avatarUrl}
@@ -111,7 +111,7 @@ const Profile: React.FC<ProfileProps> = ({
 						</div>
 					)}
 
-					<div className="avatar-actions">
+					<div className="d-flex gap-2">
 						<label className="btn btn-secondary">
 							{uploading ? t("profile.uploading") : t("profile.changeAvatar")}
 							<input
@@ -135,22 +135,31 @@ const Profile: React.FC<ProfileProps> = ({
 				</div>
 
 				{/* プロフィール情報 */}
-				<div className="profile-info">
-					<div className="info-row">
-						<span className="label">{t("profile.username")}:</span>
-						<span className="value">{profile.username}</span>
+				<div className="flex-grow-1">
+					<div className="mb-4">
+						<span className="d-block fw-bold text-muted mb-1">
+							{t("profile.username")}:
+						</span>
+						<span className="d-block text-dark fs-6">{profile.username}</span>
 					</div>
 
-					<div className="info-row">
-						<span className="label">{t("profile.displayName")}:</span>
-						<span className="value">
+					<div className="mb-4">
+						<span className="d-block fw-bold text-muted mb-1">
+							{t("profile.displayName")}:
+						</span>
+						<span className="d-block text-dark fs-6">
 							{profile.displayName || t("profile.notSet")}
 						</span>
 					</div>
 
-					<div className="info-row">
-						<span className="label">{t("profile.bio")}:</span>
-						<span className="value bio">
+					<div className="mb-4">
+						<span className="d-block fw-bold text-muted mb-1">
+							{t("profile.bio")}:
+						</span>
+						<span
+							className="d-block text-dark fs-6"
+							style={{ whiteSpace: "pre-wrap", lineHeight: 1.6 }}
+						>
 							{profile.bio || t("profile.notSet")}
 						</span>
 					</div>

--- a/frontend/src/components/ProfileEdit.tsx
+++ b/frontend/src/components/ProfileEdit.tsx
@@ -55,11 +55,18 @@ const ProfileEdit: React.FC<ProfileEditProps> = ({ onCancel, onSuccess }) => {
 	};
 
 	if (loading) {
-		return <div className="profile-edit">{t("profile.loading")}</div>;
+		return (
+			<div
+				className="bg-white p-5 rounded-3 shadow-sm"
+				style={{ maxWidth: 600 }}
+			>
+				{t("profile.loading")}
+			</div>
+		);
 	}
 
 	return (
-		<div className="profile-edit">
+		<div className="bg-white p-5 rounded-3 shadow-sm" style={{ maxWidth: 600 }}>
 			<h2>{t("profileEdit.title")}</h2>
 
 			<form onSubmit={handleSubmit}>

--- a/frontend/src/components/StatsDashboard.module.css
+++ b/frontend/src/components/StatsDashboard.module.css
@@ -1,29 +1,7 @@
 .container {
-	padding: var(--space-6, 24px);
+	padding: 24px;
 	max-width: 800px;
 	margin: 0 auto;
-}
-
-.title {
-	font-size: 1.5rem;
-	font-weight: 700;
-	color: #333;
-	margin-bottom: var(--space-6, 24px);
-	text-align: left;
-}
-
-/* ============================================ */
-/* 上段: 円グラフ + カウンター */
-/* ============================================ */
-
-.summary {
-	display: flex;
-	align-items: center;
-	gap: var(--space-8, 32px);
-	background: #f8f9fa;
-	border-radius: 12px;
-	padding: var(--space-6, 24px);
-	margin-bottom: var(--space-6, 24px);
 }
 
 /* 円グラフ */
@@ -32,11 +10,6 @@
 	width: 120px;
 	height: 120px;
 	flex-shrink: 0;
-}
-
-.chart {
-	width: 100%;
-	height: 100%;
 }
 
 .chartLabel {
@@ -61,24 +34,7 @@
 	margin-top: 2px;
 }
 
-/* 勝敗カウンター */
-.counters {
-	display: flex;
-	gap: var(--space-4, 16px);
-	flex-wrap: wrap;
-}
-
-.counter {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	background: white;
-	border-radius: 10px;
-	padding: var(--space-4, 16px) var(--space-5, 20px);
-	min-width: 80px;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-}
-
+/* 勝敗カウンターの値カラー */
 .counterValue {
 	font-size: 2rem;
 	font-weight: 700;
@@ -103,99 +59,11 @@
 	color: #667eea;
 }
 
-/* ============================================ */
-/* 試合履歴テーブル */
-/* ============================================ */
-
-.historySection {
-	background: white;
-	border-radius: 12px;
-	border: 1px solid #e9ecef;
-	overflow: hidden;
-}
-
-.historyTitle {
-	font-size: 1rem;
-	font-weight: 600;
-	color: #555;
-	padding: var(--space-4, 16px) var(--space-5, 20px);
-	border-bottom: 1px solid #e9ecef;
-	margin: 0;
-	text-align: left;
-}
-
-.noHistory {
-	padding: var(--space-6, 24px);
-	text-align: center;
-	color: #888;
-}
-
-.tableWrapper {
-	overflow-x: auto;
-}
-
-.table {
-	width: 100%;
-	border-collapse: collapse;
-	font-size: 0.9rem;
-}
-
-.table th {
-	padding: 10px 16px;
-	text-align: left;
-	font-weight: 600;
-	color: #555;
-	background: #f8f9fa;
-	border-bottom: 1px solid #e9ecef;
-	white-space: nowrap;
-}
-
-.table td {
-	padding: 10px 16px;
-	border-bottom: 1px solid #f0f0f0;
-	color: #333;
-}
-
-.table tr:last-child td {
-	border-bottom: none;
-}
-
-.table tr:hover td {
-	background: #fafbff;
-}
-
-.badgeWin,
-.badgeLoss {
-	display: inline-block;
-	padding: 2px 10px;
-	border-radius: 999px;
-	font-size: 0.8rem;
-	font-weight: 600;
-}
-
-.badgeWin {
-	background: #d4edda;
-	color: #155724;
-}
-
-.badgeLoss {
-	background: #f8d7da;
-	color: #721c24;
-}
-
-/* ============================================ */
-/* ローディング・エラー */
-/* ============================================ */
-
-.loading,
-.error {
-	padding: var(--space-6, 24px);
-	text-align: center;
-	color: #888;
-}
-
-.error {
-	color: #e74c3c;
+/* min-width for counter cards */
+.counterWin,
+.counterLoss,
+.counterTotal {
+	min-width: 80px;
 }
 
 /* ============================================ */
@@ -206,9 +74,5 @@
 	.summary {
 		flex-direction: column;
 		align-items: center;
-	}
-
-	.counters {
-		justify-content: center;
 	}
 }

--- a/frontend/src/components/StatsDashboard.tsx
+++ b/frontend/src/components/StatsDashboard.tsx
@@ -109,7 +109,7 @@ export default function StatsDashboard() {
 									<th>{t("history.date")}</th>
 									<th>{t("history.result")}</th>
 									<th>{t("history.score")}</th>
-									<th>{t("stats.opponentId")}</th>
+									<th>{t("history.opponent")}</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -132,7 +132,7 @@ export default function StatsDashboard() {
 										<td>
 											{m.myScore} - {m.opponentScore}
 										</td>
-										<td>{m.opponentUserId}</td>
+										<td>{m.opponentUsername ?? "-"}</td>
 									</tr>
 								))}
 							</tbody>

--- a/frontend/src/components/StatsDashboard.tsx
+++ b/frontend/src/components/StatsDashboard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useStats } from "../hooks/useStats";
 import styles from "./StatsDashboard.module.css";
@@ -10,7 +9,7 @@ function WinRateChart({ winRate, label }: { winRate: number; label: string }) {
 	const progress = (winRate / 100) * CIRCUMFERENCE;
 	return (
 		<div className={styles.chartWrapper}>
-			<svg viewBox="0 0 100 100" className={styles.chart}>
+			<svg viewBox="0 0 100 100" className="w-100 h-100">
 				{/* 背景の円 */}
 				<circle
 					cx="50"
@@ -62,34 +61,46 @@ export default function StatsDashboard() {
 	const { stats, history, loading, error } = useStats();
 
 	if (loading) {
-		return <div className={styles.loading}>{t("common.loading")}</div>;
+		return (
+			<div className="p-4 text-center text-muted">{t("common.loading")}</div>
+		);
 	}
 
 	if (error) {
-		return <div className={styles.error}>{t(error)}</div>;
+		return <div className="p-4 text-center text-danger">{t(error)}</div>;
 	}
 
 	return (
 		<div className={styles.container}>
-			<h2 className={styles.title}>{t("stats.title")}</h2>
+			<h2 className="fs-4 fw-bold text-dark mb-4 text-start">
+				{t("stats.title")}
+			</h2>
 
 			{/* 上段：円グラフ + 勝敗カウンター */}
-			<div className={styles.summary}>
+			<div
+				className={`d-flex align-items-center gap-5 bg-light rounded-3 p-4 mb-4 ${styles.summary}`}
+			>
 				<WinRateChart
 					winRate={stats?.winRate ?? 0}
 					label={t("stats.winRate")}
 				/>
 
-				<div className={styles.counters}>
-					<div className={`${styles.counter} ${styles.counterWin}`}>
+				<div className="d-flex gap-3 flex-wrap">
+					<div
+						className={`d-flex flex-column align-items-center bg-white rounded-3 px-4 py-3 shadow-sm ${styles.counterWin}`}
+					>
 						<span className={styles.counterValue}>{stats?.wins ?? 0}</span>
 						<span className={styles.counterLabel}>{t("stats.wins")}</span>
 					</div>
-					<div className={`${styles.counter} ${styles.counterLoss}`}>
+					<div
+						className={`d-flex flex-column align-items-center bg-white rounded-3 px-4 py-3 shadow-sm ${styles.counterLoss}`}
+					>
 						<span className={styles.counterValue}>{stats?.losses ?? 0}</span>
 						<span className={styles.counterLabel}>{t("stats.losses")}</span>
 					</div>
-					<div className={`${styles.counter} ${styles.counterTotal}`}>
+					<div
+						className={`d-flex flex-column align-items-center bg-white rounded-3 px-4 py-3 shadow-sm ${styles.counterTotal}`}
+					>
 						<span className={styles.counterValue}>{stats?.total ?? 0}</span>
 						<span className={styles.counterLabel}>{t("stats.total")}</span>
 					</div>
@@ -97,19 +108,23 @@ export default function StatsDashboard() {
 			</div>
 
 			{/* 下段：試合履歴テーブル */}
-			<div className={styles.historySection}>
-				<h3 className={styles.historyTitle}>{t("stats.historyTitle")}</h3>
+			<div className="bg-white rounded-3 border overflow-hidden">
+				<h3 className="fs-6 fw-semibold text-muted px-4 py-3 border-bottom mb-0 text-start">
+					{t("stats.historyTitle")}
+				</h3>
 				{history.length === 0 ? (
-					<div className={styles.noHistory}>{t("history.noHistory")}</div>
+					<div className="p-4 text-center text-muted">
+						{t("history.noHistory")}
+					</div>
 				) : (
-					<div className={styles.tableWrapper}>
-						<table className={styles.table}>
-							<thead>
+					<div className="table-responsive">
+						<table className="table table-hover mb-0">
+							<thead className="table-light">
 								<tr>
-									<th>{t("history.date")}</th>
-									<th>{t("history.result")}</th>
-									<th>{t("history.score")}</th>
-									<th>{t("history.opponent")}</th>
+									<th className="text-nowrap">{t("history.date")}</th>
+									<th className="text-nowrap">{t("history.result")}</th>
+									<th className="text-nowrap">{t("history.score")}</th>
+									<th className="text-nowrap">{t("history.opponent")}</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -120,8 +135,8 @@ export default function StatsDashboard() {
 											<span
 												className={
 													m.result === "win"
-														? styles.badgeWin
-														: styles.badgeLoss
+														? "badge rounded-pill bg-success bg-opacity-25 text-success"
+														: "badge rounded-pill bg-danger bg-opacity-25 text-danger"
 												}
 											>
 												{m.result === "win"

--- a/frontend/src/components/TwoFASettings.tsx
+++ b/frontend/src/components/TwoFASettings.tsx
@@ -67,10 +67,10 @@ function TwoFASettings({ is2FAEnabled, onStatusChange }: TwoFASettingsProps) {
 	};
 
 	return (
-		<div className="twofa-settings">
-			<h3>{t("twofa.title")}</h3>
+		<div className="mt-5 px-5 py-4 bg-white rounded-3 shadow-sm text-center">
+			<h3 className="text-dark mb-2 fs-5">{t("twofa.title")}</h3>
 
-			<p className="twofa-status">
+			<p className="d-flex align-items-center justify-content-center gap-2 text-muted">
 				<span
 					className={`twofa-status-dot ${is2FAEnabled ? "enabled" : "disabled"}`}
 				/>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -30,7 +30,19 @@
 	},
 	"home": {
 		"welcome": "Welcome, {{username}}!",
-		"userId": "User ID"
+		"userId": "User ID",
+		"welcomeLabel": "Welcome",
+		"hello": "Hello",
+		"san": "",
+		"description": "ft_transcendence is a Pong gaming platform where you can play online or against AI. Compete with players worldwide and climb the rankings.",
+		"ctaOnline": "Play Online",
+		"ctaAi": "Play vs AI",
+		"cardOnlineTitle": "Online Match",
+		"cardOnlineDesc": "Play in real-time against other players. Win matches and climb the global rankings.",
+		"cardAiTitle": "AI Mode",
+		"cardAiDesc": "Practice against AI at your own pace. Adjust difficulty and sharpen your skills.",
+		"cardRankTitle": "Leaderboard",
+		"cardRankDesc": "Check rankings for all players. Win rate and scores determine your global standing."
 	},
 	"profile": {
 		"title": "Profile",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -30,7 +30,19 @@
 	},
 	"home": {
 		"welcome": "Bienvenue, {{username}} !",
-		"userId": "ID utilisateur"
+		"userId": "ID utilisateur",
+		"welcomeLabel": "Bienvenue",
+		"hello": "Bonjour",
+		"san": "",
+		"description": "ft_transcendence est une plateforme de jeu Pong où vous pouvez jouer en ligne ou contre l'IA. Affrontez des joueurs du monde entier et grimpez dans le classement.",
+		"ctaOnline": "Jouer en ligne",
+		"ctaAi": "Jouer contre l'IA",
+		"cardOnlineTitle": "Match en ligne",
+		"cardOnlineDesc": "Jouez en temps réel contre d'autres joueurs. Gagnez des matchs et montez dans le classement mondial.",
+		"cardAiTitle": "Mode IA",
+		"cardAiDesc": "Entraînez-vous contre l'IA à votre rythme. Ajustez la difficulté et améliorez vos compétences.",
+		"cardRankTitle": "Classement",
+		"cardRankDesc": "Consultez le classement de tous les joueurs. Le taux de victoire et les scores déterminent votre rang mondial."
 	},
 	"profile": {
 		"title": "Profil",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -30,7 +30,19 @@
 	},
 	"home": {
 		"welcome": "ようこそ、{{username}}さん！",
-		"userId": "ユーザーID"
+		"userId": "ユーザーID",
+		"welcomeLabel": "ようこそ",
+		"hello": "こんにちは",
+		"san": " さん",
+		"description": "ft_transcendence は、オンライン対戦とAI対戦が楽しめる Pong ゲームプラットフォームです。ランキングで世界中のプレイヤーと競い合い、実力を磨きましょう。",
+		"ctaOnline": "オンラインモードで遊ぶ",
+		"ctaAi": "AIと対戦する",
+		"cardOnlineTitle": "オンライン対戦",
+		"cardOnlineDesc": "リアルタイムでほかのプレイヤーと対戦。勝ち抜いてランキング上位を目指そう。",
+		"cardAiTitle": "AIモード",
+		"cardAiDesc": "AIを相手に練習できるモード。難易度を調整して自分のペースで実力アップ。",
+		"cardRankTitle": "ランキング",
+		"cardRankDesc": "全プレイヤーの成績を確認。勝率やスコアで順位が決まるグローバル対戦記録。"
 	},
 	"profile": {
 		"title": "プロフィール",

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,50 +1,10 @@
 /* ============================================ */
 /* デザイントークン（CSS カスタムプロパティ）    */
+/* Bootstrap 5のユーティリティと重複するトークン */
+/* は削除済み。プロジェクト固有の値のみ残す。    */
 /* ============================================ */
 
 :root {
-	/* スペーシング */
-	--space-1: 4px;
-	--space-2: 8px;
-	--space-3: 12px;
-	--space-4: 16px;
-	--space-5: 20px;
-	--space-6: 24px;
-	--space-7: 28px;
-	--space-8: 32px;
-
-	/* カラー */
-	--color-primary: #667eea;
-	--color-primary-dark: #764ba2;
-	--color-success: #28a745;
-	--color-danger: #e74c3c;
-	--color-warning: #ffc107;
-	--color-secondary: #6c757d;
-	--color-text: #333;
-	--color-text-muted: #888;
-	--color-border: #e9ecef;
-	--color-bg-light: #f8f9fa;
-	--color-white: #fff;
-
-	/* タイポグラフィ */
-	--font-size-xs: 0.75rem;
-	--font-size-sm: 0.875rem;
-	--font-size-md: 1rem;
-	--font-size-lg: 1.125rem;
-	--font-size-xl: 1.5rem;
-	--font-size-2xl: 2rem;
-
-	/* ボーダー半径 */
-	--radius-sm: 5px;
-	--radius-md: 10px;
-	--radius-lg: 15px;
-	--radius-full: 999px;
-
-	/* シャドウ */
-	--shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.06);
-	--shadow-md: 0 4px 20px rgba(0, 0, 0, 0.1);
-	--shadow-lg: 0 10px 40px rgba(0, 0, 0, 0.2);
-
 	/* サイドバー幅 */
 	--sidebar-width: 250px;
 
@@ -52,14 +12,6 @@
 	--transition-fast: 0.15s ease;
 	--transition-base: 0.3s ease;
 }
-
-/* ============================================ */
-/* ブレークポイント                              */
-/* xs: ~480px  (スマートフォン縦)               */
-/* sm: ~768px  (スマートフォン横 / タブレット)  */
-/* md: ~1024px (タブレット横 / 小さいPC)        */
-/* lg: 1025px+ (デスクトップ)                   */
-/* ============================================ */
 
 /* ============================================ */
 /* モバイルヘッダー（デスクトップでは非表示）    */
@@ -109,10 +61,10 @@
 		position: fixed;
 		top: 0;
 		left: 0;
-		width: 250px;
+		width: var(--sidebar-width);
 		height: 100vh;
 		transform: translateX(-100%);
-		transition: transform 0.3s ease;
+		transition: transform var(--transition-base);
 		z-index: 1001;
 		flex-direction: column;
 		overflow-y: auto;
@@ -122,7 +74,7 @@
 		transform: translateX(0);
 	}
 
-	/* 暗いオーバーレイ（常にDOMに存在、opacity で切替） */
+	/* 暗いオーバーレイ */
 	.sidebar-overlay {
 		display: block;
 		position: fixed;
@@ -132,8 +84,8 @@
 		opacity: 0;
 		visibility: hidden;
 		transition:
-			opacity 0.3s ease,
-			visibility 0.3s ease;
+			opacity var(--transition-base),
+			visibility var(--transition-base);
 	}
 
 	.sidebar-overlay.visible {
@@ -190,27 +142,12 @@
 }
 
 /* ============================================ */
-/* サイドバーヘッダー: 言語ボタンのはみ出し修正 */
-/* ============================================ */
-
-.sidebar-header h1 {
-	flex: 1;
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.sidebar-header .lang-toggle {
-	flex-shrink: 0;
-}
-
-/* ============================================ */
 /* プロフィール: スマートフォン縦向き対応       */
 /* ============================================ */
 
 @media (max-width: 600px) {
-	.profile-content {
+	/* profile-content はBootstrapの d-flex に移行済み */
+	.profile > .d-flex {
 		flex-direction: column;
 		align-items: center;
 		gap: 20px;
@@ -226,10 +163,6 @@
 	.avatar-placeholder {
 		font-size: 3.5rem;
 	}
-
-	.profile-info {
-		width: 100%;
-	}
 }
 
 /* ============================================ */
@@ -237,11 +170,6 @@
 /* ============================================ */
 
 @media (max-width: 768px) {
-	/* main-content-inner のパディングをチャット時に縮小 */
-	.main-content-inner:has(.chat-page) {
-		padding: 12px;
-	}
-
 	/* チャットページの高さをビューポートに合わせる */
 	.chat-page {
 		height: calc(100dvh - 220px);


### PR DESCRIPTION
## 概要

Milestone 9 のフロントエンド作業として、UI フレームワークの Bootstrap 5 への移行と、ホーム画面・i18n の追加、及び既存画面の細かな修正を行いました。

## 主な変更内容

### 1. Bootstrap 5 へのスタイル移行（b6677f8）

独自記述していた App.css の大半を Bootstrap のユーティリティクラスに置き換え、CSS の保守性を向上させました。
- 削除: App.css 約 700 行の独自ルールを削除（1020 行 → 約 320 行）
- 置換: 認証フォーム・ボタン・テーブル・モーダル・チャット等を Bootstrap クラス（`btn`, `form-control`, `table`, `d-flex`, `rounded-3`, `shadow-sm` 等）に移行
- 残した独自 CSS: レスポンシブ用の `responsive.css`、テーマ色の `theme.css`、及びコンポーネント固有の CSS Module（`StatsDashboard.module.css` / `GdprSettings.module.css` / `ConfirmDialog.module.css`）

### 2. ホーム画面 UI と i18n 対応（6d8fa67）

ログイン直後のホーム画面に、機能紹介カード（Online / AI / Rank）を追加しました。合わせて 3 言語（ja / en / fr）の翻訳キーを追加しています。

### 3. 統計ページの対戦相手表示修正（6b8f234）

StatsDashboard で対戦相手がユーザー ID のまま表示されていたバグを修正し、username を表示するように変更。

### 4. FriendRequests の不要クラス削除（ecc3f33）

App.css から削除済みの `.request-status` クラスが className に残っていたため削除。

## 残存インラインスタイルについて

Bootstrap のユーティリティで置き換えられなかった箇所が一部あります。理由は大きく3パターンです。

**① Bootstrap のトークンが粒度不足**
- `lineHeight: 1.6`（App.tsx / Profile.tsx） → Bootstrap は 1.25 / 1.5 / 2.0 の3段階のみで 1.6 に相当するものがない
- `fontSize: "0.75rem"`（フッター） → `small` は 0.875rem で元デザインより大きくなる

**② 任意ピクセル値の最大幅指定が不可**
- `maxWidth: 600 / 420`（ProfileEdit / GdprSettings） → Bootstrap のコンテナ幅は breakpoint ベースで固定値指定に対応していない

**③ 値がランタイムで動的に変化する**
- `PongCanvas.tsx` → Canvas のスケーリング（`transform: scale()`、`width` 等）は実行時に計算される値
- `GamePage.tsx` オーバーレイ → ゲーム専用の色（`rgba(0,0,0,0.8)`、`#ffaa00` 等）は Bootstrap テーマに存在しない

**その他の慣用パターン**
- `display: "none"`（Profile.tsx） → `<input type="file">` を非表示にする定番実装
- `whiteSpace: "pre-wrap"`（Profile.tsx） → Bio 欄の改行保持。Bootstrap に該当ユーティリティなし

## 動作確認

- [ ] Chrome 最新版で主要画面（Home / Auth / Profile / Chat / Stats / GDPR / Game）の表示崩れが無いこと
- [ ] Firefox 最新版で同上
- [ ] モバイル幅（iPhone SE: 375px）で崩れが無いこと
- [ ] 3 言語（ja / en / fr）の切り替えでホーム画面のテキストが正しく表示されること
- [ ] 統計ページで対戦相手が username で表示されること

---