### PR TITLE
fix: ログイン画面のメッセージが残る問題を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -492,13 +492,19 @@ function App() {
 									<div className="tabs">
 										<button
 											className={isLogin ? "active" : ""}
-											onClick={() => setIsLogin(true)}
+											onClick={() => {
+												setIsLogin(true);
+												setMessage("");
+											}}
 										>
 											{t("auth.login")}
 										</button>
 										<button
 											className={!isLogin ? "active" : ""}
-											onClick={() => setIsLogin(false)}
+											onClick={() => {
+												setIsLogin(false);
+												setMessage("");
+											}}
 										>
 											{t("auth.register")}
 										</button>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -305,6 +305,7 @@ function App() {
 						onAccountDeleted={() => {
 							setUser(null);
 							setCurrentPage("home");
+							setMessage("");
 							localStorage.removeItem("hasLoggedIn");
 						}}
 					/>


### PR DESCRIPTION
## Summary
- ログイン/登録タブ切り替え時に「ログイン成功」「ログアウトしました」等のメッセージをクリアするよう修正
- アカウント削除後にログイン画面へ戻った際「ログイン成功！」が残る問題を修正

## Test plan
- [ ] ログアウト後「ログアウトしました」表示 → 登録タブに切り替え → メッセージが消えることを確認
- [ ] アカウント削除後、ログイン画面に「ログイン成功！」が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)