### PR TITLE
fix: バックエンドのハードコード日本語メッセージをi18nキーに置換

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -93,7 +93,10 @@ export class AuthController {
 	) {
 		const user = req.user;
 		if (!user) {
-			throw new HttpException("42認証に失敗しました", HttpStatus.UNAUTHORIZED);
+			throw new HttpException(
+				"errors.auth.fortyTwoFailed",
+				HttpStatus.UNAUTHORIZED,
+			);
 		}
 
 		const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3001";
@@ -135,7 +138,7 @@ export class AuthController {
 			setJwtCookie(res, token);
 			return {
 				success: true,
-				message: "登録成功",
+				message: "success.auth.registered",
 				user: { id: user.id, username: user.username },
 			};
 		} catch (error) {
@@ -156,7 +159,7 @@ export class AuthController {
 		if (!user) {
 			return {
 				success: false,
-				message: "ユーザー名またはパスワードが間違っています",
+				message: "errors.auth.invalidCredentials",
 			};
 		}
 
@@ -180,7 +183,7 @@ export class AuthController {
 		setJwtCookie(res, token);
 		return {
 			success: true,
-			message: "ログイン成功",
+			message: "success.auth.loggedIn",
 			user: { id: user.id, username: user.username },
 		};
 	}
@@ -199,18 +202,18 @@ export class AuthController {
 		if (!tempToken) {
 			return {
 				success: false,
-				message: "セッションが無効です。再度ログインしてください",
+				message: "errors.auth.sessionInvalid",
 			};
 		}
 
 		const payload = this.authService.verifyTempToken(tempToken);
 		if (!payload) {
-			return { success: false, message: "セッションが期限切れです" };
+			return { success: false, message: "errors.auth.sessionExpired" };
 		}
 
 		const user = await this.authService.findById(payload.sub);
 		if (!user || !user.two_factor_secret) {
-			return { success: false, message: "ユーザーが見つかりません" };
+			return { success: false, message: "errors.auth.userNotFound" };
 		}
 
 		const isValid = this.twoFactorService.verifyToken(
@@ -218,7 +221,7 @@ export class AuthController {
 			body.token,
 		);
 		if (!isValid) {
-			return { success: false, message: "コードが正しくありません" };
+			return { success: false, message: "errors.auth.invalidCode" };
 		}
 
 		// 検証OK → 本物のJWTを発行
@@ -226,7 +229,7 @@ export class AuthController {
 		const accessToken = this.authService.generateToken(user);
 		setJwtCookie(res, accessToken);
 
-		return { success: true, message: "2FA認証成功" };
+		return { success: true, message: "success.auth.twoFaVerified" };
 	}
 
 	// POST /auth/2fa/setup - QRコードを生成して返す
@@ -234,7 +237,7 @@ export class AuthController {
 	async setupTwoFactor(@Req() req: AuthenticatedRequest) {
 		const fullUser = await this.authService.findById(req.user.id);
 		if (!fullUser)
-			return { success: false, message: "ユーザーが見つかりません" };
+			return { success: false, message: "errors.auth.userNotFound" };
 
 		return this.twoFactorService.generateSecret(fullUser);
 	}
@@ -247,17 +250,17 @@ export class AuthController {
 	) {
 		const fullUser = await this.authService.findById(req.user.id);
 		if (!fullUser)
-			return { success: false, message: "ユーザーが見つかりません" };
+			return { success: false, message: "errors.auth.userNotFound" };
 
 		const success = await this.twoFactorService.enableTwoFactor(
 			fullUser,
 			body.token,
 		);
 		if (!success) {
-			return { success: false, message: "コードが正しくありません" };
+			return { success: false, message: "errors.auth.invalidCode" };
 		}
 
-		return { success: true, message: "2FAを有効化しました" };
+		return { success: true, message: "success.auth.twoFaEnabled" };
 	}
 
 	// POST /auth/2fa/disable - 2FAを無効化
@@ -265,10 +268,10 @@ export class AuthController {
 	async disableTwoFactor(@Req() req: AuthenticatedRequest) {
 		const fullUser = await this.authService.findById(req.user.id);
 		if (!fullUser)
-			return { success: false, message: "ユーザーが見つかりません" };
+			return { success: false, message: "errors.auth.userNotFound" };
 
 		await this.twoFactorService.disableTwoFactor(fullUser);
-		return { success: true, message: "2FAを無効化しました" };
+		return { success: true, message: "success.auth.twoFaDisabled" };
 	}
 
 	// --- その他 ---
@@ -291,6 +294,6 @@ export class AuthController {
 		res.clearCookie("access_token");
 		res.clearCookie("logged_in");
 		res.clearCookie("temp_token");
-		return { success: true, message: "ログアウト成功" };
+		return { success: true, message: "success.auth.loggedOut" };
 	}
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -54,7 +54,7 @@ export class AuthService {
 		});
 
 		if (existingUser) {
-			throw new Error("ユーザー名は既に使用されています");
+			throw new Error("errors.auth.usernameAlreadyExists");
 		}
 
 		// --- 追加: パスワードのハッシュ化 ---

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,13 +1,13 @@
 import { IsString, IsNotEmpty, MaxLength } from "class-validator";
 
 export class LoginDto {
-	@IsString({ message: "ユーザー名は文字列で入力してください" })
-	@IsNotEmpty({ message: "ユーザー名は必須です" })
-	@MaxLength(20, { message: "ユーザー名は20文字以内で入力してください" })
+	@IsString({ message: "errors.validation.username.isString" })
+	@IsNotEmpty({ message: "errors.validation.username.required" })
+	@MaxLength(20, { message: "errors.validation.username.maxLength" })
 	username: string;
 
-	@IsString({ message: "パスワードは文字列で入力してください" })
-	@IsNotEmpty({ message: "パスワードは必須です" })
-	@MaxLength(64, { message: "パスワードは64文字以内で入力してください" })
+	@IsString({ message: "errors.validation.password.isString" })
+	@IsNotEmpty({ message: "errors.validation.password.required" })
+	@MaxLength(64, { message: "errors.validation.password.maxLength" })
 	password: string;
 }

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -8,19 +8,19 @@ import {
 
 export class RegisterDto {
 	// ユーザー名: 3〜20文字、英数字・アンダースコア・ハイフンのみ
-	@IsString({ message: "ユーザー名は文字列で入力してください" })
-	@IsNotEmpty({ message: "ユーザー名は必須です" })
-	@MinLength(3, { message: "ユーザー名は3文字以上で入力してください" })
-	@MaxLength(20, { message: "ユーザー名は20文字以内で入力してください" })
+	@IsString({ message: "errors.validation.username.isString" })
+	@IsNotEmpty({ message: "errors.validation.username.required" })
+	@MinLength(3, { message: "errors.validation.username.minLength" })
+	@MaxLength(20, { message: "errors.validation.username.maxLength" })
 	@Matches(/^[a-zA-Z0-9_-]+$/, {
-		message: "ユーザー名は英数字・アンダースコア・ハイフンのみ使用できます",
+		message: "errors.validation.username.pattern",
 	})
 	username: string;
 
 	// パスワード: 8〜64文字
-	@IsString({ message: "パスワードは文字列で入力してください" })
-	@IsNotEmpty({ message: "パスワードは必須です" })
-	@MinLength(8, { message: "パスワードは8文字以上で入力してください" })
-	@MaxLength(64, { message: "パスワードは64文字以内で入力してください" })
+	@IsString({ message: "errors.validation.password.isString" })
+	@IsNotEmpty({ message: "errors.validation.password.required" })
+	@MinLength(8, { message: "errors.validation.password.minLength" })
+	@MaxLength(64, { message: "errors.validation.password.maxLength" })
 	password: string;
 }

--- a/backend/src/auth/dto/verify-2fa.dto.ts
+++ b/backend/src/auth/dto/verify-2fa.dto.ts
@@ -2,9 +2,9 @@ import { IsString, IsNotEmpty, Length, Matches } from "class-validator";
 
 export class VerifyTwoFactorDto {
 	// TOTPコード: 必ず6桁の数字
-	@IsString({ message: "コードは文字列で入力してください" })
-	@IsNotEmpty({ message: "コードは必須です" })
-	@Length(6, 6, { message: "コードは6桁で入力してください" })
-	@Matches(/^\d{6}$/, { message: "コードは数字6桁で入力してください" })
+	@IsString({ message: "errors.validation.code.isString" })
+	@IsNotEmpty({ message: "errors.validation.code.required" })
+	@Length(6, 6, { message: "errors.validation.code.length" })
+	@Matches(/^\d{6}$/, { message: "errors.validation.code.pattern" })
 	token: string;
 }

--- a/backend/src/friend/friend.controller.ts
+++ b/backend/src/friend/friend.controller.ts
@@ -40,7 +40,7 @@ export class FriendController {
 		if (!receiverIdOrUsername) {
 			return {
 				success: false,
-				message: "receiverId または username が必要です",
+				message: "errors.friend.receiverRequired",
 			};
 		}
 
@@ -51,7 +51,7 @@ export class FriendController {
 			);
 			return {
 				success: true,
-				message: "フレンドリクエストを送信しました",
+				message: "success.friend.requestSent",
 				friendRequest: {
 					id: request.id,
 					senderId: request.senderId,
@@ -75,12 +75,12 @@ export class FriendController {
 
 		const id = parseInt(requestId, 10);
 		if (isNaN(id)) {
-			return { success: false, message: "無効なリクエストIDです" };
+			return { success: false, message: "errors.friend.invalidRequestId" };
 		}
 
 		try {
 			await this.friendService.acceptFriendRequest(id, user.id);
-			return { success: true, message: "フレンドリクエストを承認しました" };
+			return { success: true, message: "success.friend.requestAccepted" };
 		} catch (error) {
 			return { success: false, message: (error as Error).message };
 		}
@@ -96,12 +96,12 @@ export class FriendController {
 
 		const id = parseInt(requestId, 10);
 		if (isNaN(id)) {
-			return { success: false, message: "無効なリクエストIDです" };
+			return { success: false, message: "errors.friend.invalidRequestId" };
 		}
 
 		try {
 			await this.friendService.rejectFriendRequest(id, user.id);
-			return { success: true, message: "フレンドリクエストを拒否しました" };
+			return { success: true, message: "success.friend.requestRejected" };
 		} catch (error) {
 			return { success: false, message: (error as Error).message };
 		}
@@ -117,12 +117,12 @@ export class FriendController {
 
 		const id = parseInt(friendId, 10);
 		if (isNaN(id)) {
-			return { success: false, message: "無効なユーザーIDです" };
+			return { success: false, message: "errors.friend.invalidUserId" };
 		}
 
 		try {
 			await this.friendService.removeFriend(user.id, id);
-			return { success: true, message: "フレンドを削除しました" };
+			return { success: true, message: "success.friend.friendRemoved" };
 		} catch (error) {
 			return { success: false, message: (error as Error).message };
 		}

--- a/backend/src/profile/dto/update-profile.dto.ts
+++ b/backend/src/profile/dto/update-profile.dto.ts
@@ -3,15 +3,15 @@ import { IsString, IsOptional, MaxLength, Matches } from "class-validator";
 export class UpdateProfileDto {
 	// 表示名: オプション、50文字以内
 	@IsOptional()
-	@IsString({ message: "表示名は文字列で入力してください" })
-	@MaxLength(50, { message: "表示名は50文字以内で入力してください" })
-	@Matches(/^[^<>]*$/, { message: "表示名にHTMLタグは使用できません" })
+	@IsString({ message: "errors.validation.displayName.isString" })
+	@MaxLength(50, { message: "errors.validation.displayName.maxLength" })
+	@Matches(/^[^<>]*$/, { message: "errors.validation.displayName.noHtml" })
 	displayName?: string;
 
 	// 自己紹介: オプション、500文字以内
 	@IsOptional()
-	@IsString({ message: "自己紹介は文字列で入力してください" })
-	@MaxLength(500, { message: "自己紹介は500文字以内で入力してください" })
-	@Matches(/^[^<>]*$/, { message: "自己紹介にHTMLタグは使用できません" })
+	@IsString({ message: "errors.validation.bio.isString" })
+	@MaxLength(500, { message: "errors.validation.bio.maxLength" })
+	@Matches(/^[^<>]*$/, { message: "errors.validation.bio.noHtml" })
 	bio?: string;
 }

--- a/backend/src/profile/profile.controller.ts
+++ b/backend/src/profile/profile.controller.ts
@@ -53,7 +53,7 @@ export class ProfileController {
 	): Promise<GetProfileResponse | { success: false; message: string }> {
 		const userId = parseInt(id, 10);
 		if (isNaN(userId)) {
-			return { success: false, message: "無効なユーザーIDです" };
+			return { success: false, message: "errors.profile.invalidUserId" };
 		}
 
 		try {
@@ -77,7 +77,7 @@ export class ProfileController {
 
 		return {
 			success: true,
-			message: "プロフィールを更新しました",
+			message: "success.profile.updated",
 			profile,
 		};
 	}
@@ -117,7 +117,7 @@ export class ProfileController {
 			// fileFilterで拒否された場合（画像以外）もここに来る
 			return {
 				success: false,
-				message: "画像ファイルのみアップロード可能です（jpg/jpeg/png/gif）",
+				message: "errors.profile.avatarImageOnly",
 			};
 		}
 
@@ -126,7 +126,7 @@ export class ProfileController {
 
 		return {
 			success: true,
-			message: "アバターをアップロードしました",
+			message: "success.profile.avatarUploaded",
 			avatarUrl,
 		};
 	}
@@ -141,7 +141,7 @@ export class ProfileController {
 
 		return {
 			success: true,
-			message: "アバターを削除しました",
+			message: "success.profile.avatarDeleted",
 		};
 	}
 }

--- a/backend/src/profile/profile.service.ts
+++ b/backend/src/profile/profile.service.ts
@@ -22,7 +22,7 @@ export class ProfileService {
 		// ユーザー情報を取得
 		const user = await this.userRepository.findOne({ where: { id: userId } });
 		if (!user) {
-			throw new NotFoundException("ユーザーが見つかりません");
+			throw new NotFoundException("errors.auth.userNotFound");
 		}
 
 		// プロフィール情報を取得（存在しない場合は自動作成）

--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { getMyProfile, uploadAvatar, deleteAvatar } from "../api";
+import { translateMessage } from "../utils/translateMessage";
 import type { GetProfileResponse } from "/shared";
 import TwoFASettings from "./TwoFASettings";
 
@@ -60,7 +61,7 @@ const Profile: React.FC<ProfileProps> = ({
 
 		try {
 			const response = await uploadAvatar(file);
-			setMessage(response.message);
+			setMessage(translateMessage(response.message));
 			// プロフィールを再読み込み
 			await loadProfile();
 		} catch (err) {
@@ -76,7 +77,7 @@ const Profile: React.FC<ProfileProps> = ({
 
 		try {
 			const response = await deleteAvatar();
-			setMessage(response.message);
+			setMessage(translateMessage(response.message));
 			await loadProfile();
 		} catch (err) {
 			const error = err as { response?: { data?: { message?: string } } };

--- a/frontend/src/components/ProfileEdit.tsx
+++ b/frontend/src/components/ProfileEdit.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { getMyProfile, updateProfile } from "../api";
+import { translateMessage } from "../utils/translateMessage";
 
 interface ProfileEditProps {
 	onCancel: () => void;
@@ -41,7 +42,7 @@ const ProfileEdit: React.FC<ProfileEditProps> = ({ onCancel, onSuccess }) => {
 				displayName: displayName.trim() || undefined,
 				bio: bio.trim() || undefined,
 			});
-			setMessage(response.message);
+			setMessage(translateMessage(response.message));
 			setTimeout(() => {
 				onSuccess();
 			}, 1000);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -210,7 +210,49 @@
 	},
 	"errors": {
 		"auth": {
-			"loginRequired": "Login required"
+			"loginRequired": "Login required",
+			"fortyTwoFailed": "42 authentication failed",
+			"invalidCredentials": "Invalid username or password",
+			"sessionInvalid": "Session is invalid. Please log in again",
+			"sessionExpired": "Session has expired",
+			"userNotFound": "User not found",
+			"invalidCode": "Invalid code",
+			"usernameAlreadyExists": "Username is already taken"
+		},
+		"validation": {
+			"username": {
+				"isString": "Username must be a string",
+				"required": "Username is required",
+				"minLength": "Username must be at least 3 characters",
+				"maxLength": "Username must be 20 characters or less",
+				"pattern": "Username can only contain letters, numbers, underscores, and hyphens"
+			},
+			"password": {
+				"isString": "Password must be a string",
+				"required": "Password is required",
+				"minLength": "Password must be at least 8 characters",
+				"maxLength": "Password must be 64 characters or less"
+			},
+			"code": {
+				"isString": "Code must be a string",
+				"required": "Code is required",
+				"length": "Code must be 6 digits",
+				"pattern": "Code must be exactly 6 digits"
+			},
+			"displayName": {
+				"isString": "Display name must be a string",
+				"maxLength": "Display name must be 50 characters or less",
+				"noHtml": "Display name cannot contain HTML tags"
+			},
+			"bio": {
+				"isString": "Bio must be a string",
+				"maxLength": "Bio must be 500 characters or less",
+				"noHtml": "Bio cannot contain HTML tags"
+			}
+		},
+		"profile": {
+			"invalidUserId": "Invalid user ID",
+			"avatarImageOnly": "Only image files can be uploaded (jpg/jpeg/png/gif)"
 		},
 		"friend": {
 			"userNotFound": "User not found",
@@ -227,6 +269,19 @@
 		}
 	},
 	"success": {
+		"auth": {
+			"registered": "Registration successful",
+			"loggedIn": "Login successful",
+			"twoFaVerified": "2FA verification successful",
+			"twoFaEnabled": "2FA has been enabled",
+			"twoFaDisabled": "2FA has been disabled",
+			"loggedOut": "Logged out"
+		},
+		"profile": {
+			"updated": "Profile updated",
+			"avatarUploaded": "Avatar uploaded",
+			"avatarDeleted": "Avatar deleted"
+		},
 		"friend": {
 			"requestSent": "Friend request sent",
 			"requestAccepted": "Friend request accepted",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -210,7 +210,49 @@
 	},
 	"errors": {
 		"auth": {
-			"loginRequired": "Connexion requise"
+			"loginRequired": "Connexion requise",
+			"fortyTwoFailed": "Échec de l'authentification 42",
+			"invalidCredentials": "Nom d'utilisateur ou mot de passe incorrect",
+			"sessionInvalid": "Session invalide. Veuillez vous reconnecter",
+			"sessionExpired": "La session a expiré",
+			"userNotFound": "Utilisateur introuvable",
+			"invalidCode": "Code incorrect",
+			"usernameAlreadyExists": "Ce nom d'utilisateur est déjà utilisé"
+		},
+		"validation": {
+			"username": {
+				"isString": "Le nom d'utilisateur doit être une chaîne de caractères",
+				"required": "Le nom d'utilisateur est requis",
+				"minLength": "Le nom d'utilisateur doit contenir au moins 3 caractères",
+				"maxLength": "Le nom d'utilisateur doit contenir 20 caractères ou moins",
+				"pattern": "Le nom d'utilisateur ne peut contenir que des lettres, chiffres, underscores et tirets"
+			},
+			"password": {
+				"isString": "Le mot de passe doit être une chaîne de caractères",
+				"required": "Le mot de passe est requis",
+				"minLength": "Le mot de passe doit contenir au moins 8 caractères",
+				"maxLength": "Le mot de passe doit contenir 64 caractères ou moins"
+			},
+			"code": {
+				"isString": "Le code doit être une chaîne de caractères",
+				"required": "Le code est requis",
+				"length": "Le code doit contenir 6 chiffres",
+				"pattern": "Le code doit être composé de 6 chiffres exactement"
+			},
+			"displayName": {
+				"isString": "Le nom d'affichage doit être une chaîne de caractères",
+				"maxLength": "Le nom d'affichage doit contenir 50 caractères ou moins",
+				"noHtml": "Le nom d'affichage ne peut pas contenir de balises HTML"
+			},
+			"bio": {
+				"isString": "La biographie doit être une chaîne de caractères",
+				"maxLength": "La biographie doit contenir 500 caractères ou moins",
+				"noHtml": "La biographie ne peut pas contenir de balises HTML"
+			}
+		},
+		"profile": {
+			"invalidUserId": "ID utilisateur invalide",
+			"avatarImageOnly": "Seuls les fichiers image sont acceptés (jpg/jpeg/png/gif)"
 		},
 		"friend": {
 			"userNotFound": "Utilisateur introuvable",
@@ -227,6 +269,19 @@
 		}
 	},
 	"success": {
+		"auth": {
+			"registered": "Inscription réussie",
+			"loggedIn": "Connexion réussie",
+			"twoFaVerified": "Vérification 2FA réussie",
+			"twoFaEnabled": "2FA activé",
+			"twoFaDisabled": "2FA désactivé",
+			"loggedOut": "Déconnecté"
+		},
+		"profile": {
+			"updated": "Profil mis à jour",
+			"avatarUploaded": "Avatar téléchargé",
+			"avatarDeleted": "Avatar supprimé"
+		},
 		"friend": {
 			"requestSent": "Demande d'ami envoyée",
 			"requestAccepted": "Demande d'ami acceptée",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -210,7 +210,49 @@
 	},
 	"errors": {
 		"auth": {
-			"loginRequired": "ログインが必要です"
+			"loginRequired": "ログインが必要です",
+			"fortyTwoFailed": "42認証に失敗しました",
+			"invalidCredentials": "ユーザー名またはパスワードが間違っています",
+			"sessionInvalid": "セッションが無効です。再度ログインしてください",
+			"sessionExpired": "セッションが期限切れです",
+			"userNotFound": "ユーザーが見つかりません",
+			"invalidCode": "コードが正しくありません",
+			"usernameAlreadyExists": "ユーザー名は既に使用されています"
+		},
+		"validation": {
+			"username": {
+				"isString": "ユーザー名は文字列で入力してください",
+				"required": "ユーザー名は必須です",
+				"minLength": "ユーザー名は3文字以上で入力してください",
+				"maxLength": "ユーザー名は20文字以内で入力してください",
+				"pattern": "ユーザー名は英数字・アンダースコア・ハイフンのみ使用できます"
+			},
+			"password": {
+				"isString": "パスワードは文字列で入力してください",
+				"required": "パスワードは必須です",
+				"minLength": "パスワードは8文字以上で入力してください",
+				"maxLength": "パスワードは64文字以内で入力してください"
+			},
+			"code": {
+				"isString": "コードは文字列で入力してください",
+				"required": "コードは必須です",
+				"length": "コードは6桁で入力してください",
+				"pattern": "コードは数字6桁で入力してください"
+			},
+			"displayName": {
+				"isString": "表示名は文字列で入力してください",
+				"maxLength": "表示名は50文字以内で入力してください",
+				"noHtml": "表示名にHTMLタグは使用できません"
+			},
+			"bio": {
+				"isString": "自己紹介は文字列で入力してください",
+				"maxLength": "自己紹介は500文字以内で入力してください",
+				"noHtml": "自己紹介にHTMLタグは使用できません"
+			}
+		},
+		"profile": {
+			"invalidUserId": "無効なユーザーIDです",
+			"avatarImageOnly": "画像ファイルのみアップロード可能です（jpg/jpeg/png/gif）"
 		},
 		"friend": {
 			"userNotFound": "ユーザーが見つかりません",
@@ -227,6 +269,19 @@
 		}
 	},
 	"success": {
+		"auth": {
+			"registered": "登録成功",
+			"loggedIn": "ログイン成功",
+			"twoFaVerified": "2FA認証成功",
+			"twoFaEnabled": "2FAを有効化しました",
+			"twoFaDisabled": "2FAを無効化しました",
+			"loggedOut": "ログアウト成功"
+		},
+		"profile": {
+			"updated": "プロフィールを更新しました",
+			"avatarUploaded": "アバターをアップロードしました",
+			"avatarDeleted": "アバターを削除しました"
+		},
 		"friend": {
 			"requestSent": "フレンドリクエストを送信しました",
 			"requestAccepted": "フレンドリクエストを承認しました",


### PR DESCRIPTION
## Summary
- auth/profile/friendの全DTO・コントローラー・サービスのハードコードされた日本語メッセージを翻訳キー（例: `errors.validation.username.required`）に変更
- en.json/ja.json/fr.jsonにvalidation、auth、profileの翻訳キーを追加
- Profile.tsx/ProfileEdit.tsxに`translateMessage()`を追加し、バックエンドからの翻訳キーが正しく表示されるように修正

## Test plan

### 登録画面（App.tsx）
- [ ] 既に存在するユーザー名で登録 → 「Username is already taken」(en) / 「ユーザー名は既に使用されています」(ja)
- [ ] ユーザー名を空にして登録 → 「Username is required」(en) / 「ユーザー名は必須です」(ja)
- [ ] パスワードを7文字以下で登録 → 「Password must be at least 8 characters」(en)

### ログイン画面（App.tsx）
- [ ] 存在しないユーザー名でログイン → 「Invalid username or password」(en) / 「ユーザー名またはパスワードが間違っています」(ja)

### プロフィール画面（Profile.tsx / ProfileEdit.tsx）
- [ ] プロフィールを更新 → 「Profile updated」(en) / 「プロフィールを更新しました」(ja)
- [ ] アバターをアップロード → 「Avatar uploaded」(en) / 「アバターをアップロードしました」(ja)
- [ ] 画像以外のファイルをアップロード → 「Only image files can be uploaded (jpg/jpeg/png/gif)」(en)

### フレンド機能（FriendList.tsx / FriendRequests.tsx）
- [ ] フレンドリクエストを送信 → 「Friend request sent」(en) / 「フレンドリクエストを送信しました」(ja)
- [ ] フレンドリクエストを承認 → 「Friend request accepted」(en)

### 言語切替
- [ ] en → ja → fr の切替で上記メッセージが正しく変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)