### PR TITLE
fix: APIレスポンスのsuccessフラグ未チェックによるバグを修正

### DIFF
--- a/frontend/src/components/FriendList.tsx
+++ b/frontend/src/components/FriendList.tsx
@@ -44,6 +44,10 @@ const FriendList: React.FC<FriendListProps> = ({ onStartDM }) => {
 			const response = await sendFriendRequest({
 				username: newFriendUsername.trim(),
 			});
+			if (!response.success) {
+				setMessage(translateMessage(response.message));
+				return;
+			}
 			setMessage(translateMessage(response.message));
 			setNewFriendUsername("");
 		} catch (err) {
@@ -62,6 +66,10 @@ const FriendList: React.FC<FriendListProps> = ({ onStartDM }) => {
 
 		try {
 			const response = await removeFriend(friendId);
+			if (!response.success) {
+				setMessage(translateMessage(response.message));
+				return;
+			}
 			setMessage(translateMessage(response.message));
 			// リストを再読み込み
 			await loadFriends();

--- a/frontend/src/components/FriendRequests.tsx
+++ b/frontend/src/components/FriendRequests.tsx
@@ -41,6 +41,10 @@ const FriendRequests: React.FC = () => {
 
 		try {
 			const response = await acceptFriendRequest(requestId);
+			if (!response.success) {
+				setMessage(translateMessage(response.message));
+				return;
+			}
 			setMessage(translateMessage(response.message));
 			// リストを再読み込み
 			await loadRequests();
@@ -61,6 +65,10 @@ const FriendRequests: React.FC = () => {
 
 		try {
 			const response = await rejectFriendRequest(requestId);
+			if (!response.success) {
+				setMessage(translateMessage(response.message));
+				return;
+			}
 			setMessage(translateMessage(response.message));
 			// リストを再読み込み
 			await loadRequests();

--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -60,6 +60,10 @@ const Profile: React.FC<ProfileProps> = ({
 
 		try {
 			const response = await uploadAvatar(file);
+			if (!response.success) {
+				setMessage(response.message);
+				return;
+			}
 			setMessage(response.message);
 			// プロフィールを再読み込み
 			await loadProfile();
@@ -76,6 +80,10 @@ const Profile: React.FC<ProfileProps> = ({
 
 		try {
 			const response = await deleteAvatar();
+			if (!response.success) {
+				setMessage(response.message);
+				return;
+			}
 			setMessage(response.message);
 			await loadProfile();
 		} catch (err) {

--- a/frontend/src/components/ProfileEdit.tsx
+++ b/frontend/src/components/ProfileEdit.tsx
@@ -41,6 +41,11 @@ const ProfileEdit: React.FC<ProfileEditProps> = ({ onCancel, onSuccess }) => {
 				displayName: displayName.trim() || undefined,
 				bio: bio.trim() || undefined,
 			});
+			if (!response.success) {
+				setMessage(response.message);
+				setSaving(false);
+				return;
+			}
 			setMessage(response.message);
 			setTimeout(() => {
 				onSuccess();

--- a/frontend/src/components/TwoFASettings.tsx
+++ b/frontend/src/components/TwoFASettings.tsx
@@ -36,7 +36,11 @@ function TwoFASettings({ is2FAEnabled, onStatusChange }: TwoFASettingsProps) {
 		setLoading(true);
 		setMessage("");
 		try {
-			await enable2FA(token);
+			const data = await enable2FA(token);
+			if (!data.success) {
+				setMessage(data.message || "twofa.enableFailed");
+				return;
+			}
 			setMessage("twofa.enableSuccess");
 			setQrCode(null);
 			setToken("");
@@ -55,7 +59,11 @@ function TwoFASettings({ is2FAEnabled, onStatusChange }: TwoFASettingsProps) {
 		setLoading(true);
 		setMessage("");
 		try {
-			await disable2FA();
+			const data = await disable2FA();
+			if (!data.success) {
+				setMessage(data.message || "twofa.disableFailed");
+				return;
+			}
 			setMessage("twofa.disableSuccess");
 			onStatusChange();
 		} catch (err) {


### PR DESCRIPTION
 テストケース

 フロントエンド側で容易に再現できるテストケース:
 - [ ] 2FAで間違ったコードを入力 →
 エラーメッセージが表示される（成功扱いにならない）

 その他の変更箇所（FriendList, FriendRequests, Profile,
 ProfileEdit）はフロントエンドからエラーレスポンスを意図的に再現すること
 が難しいか、エラーレスポンス形式そのものに対する修正であるため、コード
 レビューでの確認となります。