### PR TITLE
Fix/front win notification

### DIFF
--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -13,6 +13,7 @@ import {
 	onPlayerDisconnected,
 	onPlayerReconnected,
 	onReconnectFailed,
+	reconnectGame,
 } from "../services/gameSocket";
 import type { GameState, GameStateDto } from "/shared/game.interface";
 import { AI_SOCKET_ID } from "/shared/game.constants";
@@ -49,6 +50,8 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 	const roomIdRef = useRef<string | null>(initialRoomId ?? null);
 	// このマウントで自分のゲームが開始されたかを追跡（前のゲームのgameOverを無視するため）
 	const gameStartedRef = useRef(false);
+	// Added to handle victory in case of double disconnection and single reconnection
+	const isPausedRef = useRef(false);
 
 	// WebSocket接続とイベントハンドリング
 	useEffect(() => {
@@ -56,8 +59,18 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 
 		const handleConnect = () => {
 			console.log("[GamePage] WebSocket接続成功");
+			if (mode === "online" && roomIdRef.current) {
+				console.log("[GamePage] reconnectGame:", roomIdRef.current);
+				reconnectGame(roomIdRef.current);
+				gameStartedRef.current = true;
+			}
 		};
 		socket.on("connect", handleConnect);
+
+		// in case it was already connected to the mount
+		if (socket.connected) {
+			handleConnect();
+		}
 
 		// AI対戦の場合、接続完了後にjoinAIGameを送信
 		if (mode === "ai") {
@@ -77,8 +90,9 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 			roomIdRef.current = dto.roomId;
 			gameStartedRef.current = true;
 			// 一時停止解除
-			if (isPaused) {
+			if (isPausedRef.current) {
 				setIsPaused(false);
+				isPausedRef.current = false;
 				setPauseMessage("");
 			}
 		};
@@ -108,6 +122,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 		const handlePlayerDisconnected = () => {
 			console.log("[GamePage] 対戦相手が切断");
 			setIsPaused(true);
+			isPausedRef.current = true;
 			setPauseMessage(t("game.opponentDisconnected"));
 		};
 		onPlayerDisconnected(handlePlayerDisconnected);
@@ -116,6 +131,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 		const handlePlayerReconnected = () => {
 			console.log("[GamePage] 対戦相手が再接続");
 			setIsPaused(false);
+			isPausedRef.current = false;
 			setPauseMessage("");
 		};
 		onPlayerReconnected(handlePlayerReconnected);
@@ -134,7 +150,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 			socket.off("playerReconnected", handlePlayerReconnected);
 			socket.off("reconnectFailed", handleReconnectFailed);
 		};
-	}, [mode, isPaused]);
+	}, [mode]);
 
 	// パドル操作コールバック
 	const handleMoveUp = useCallback(() => {

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -256,7 +256,11 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 									color: gameResult.isWinner ? "#00ff88" : "#ff4444",
 								}}
 							>
-								{gameResult.isWinner ? t("game.youWin") : t("game.youLose")}
+								{!gameResult.winner
+									? t("game.nobodyWin")
+									: gameResult.isWinner
+										? t("game.youWin")
+										: t("game.youLose")}
 							</h2>
 							{gameResult.reason && (
 								<p style={{ color: "#888", marginTop: 4, fontSize: 14 }}>

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -90,10 +90,14 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 			roomIdRef.current = dto.roomId;
 			gameStartedRef.current = true;
 			// 一時停止解除
-			if (isPausedRef.current) {
-				setIsPaused(false);
-				isPausedRef.current = false;
+			// getting the pause situation truth from the server
+			setIsPaused(dto.state.isPaused);
+			isPausedRef.current = dto.state.isPaused;
+
+			if (!dto.state.isPaused) {
 				setPauseMessage("");
+			} else {
+				setPauseMessage(t("game.opponentDisconnected"));
 			}
 		};
 		onUpdateState(handleUpdateState);

--- a/frontend/src/components/GamePage.tsx
+++ b/frontend/src/components/GamePage.tsx
@@ -51,6 +51,7 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 	// このマウントで自分のゲームが開始されたかを追跡（前のゲームのgameOverを無視するため）
 	const gameStartedRef = useRef(false);
 	// Added to handle victory in case of double disconnection and single reconnection
+	// 二重切断と単一再接続のケースでの勝敗処理を扱うために追加
 	const isPausedRef = useRef(false);
 
 	// WebSocket接続とイベントハンドリング
@@ -67,7 +68,10 @@ function GamePage({ mode, roomId: initialRoomId, onBack }: GamePageProps) {
 		};
 		socket.on("connect", handleConnect);
 
-		// in case it was already connected to the mount
+		// If the socket is already connected at mount time,
+		// manually trigger the same logic as "connect"
+		// マウント時点ですでにソケットが接続済みの場合を考慮し、
+		// "connect" イベントと同じ処理を手動で実行する
 		if (socket.connected) {
 			handleConnect();
 		}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -118,6 +118,7 @@
 		"controls": "Controls",
 		"youWin": "YOU WIN!",
 		"youLose": "YOU LOSE",
+		"nobodyWin": "DRAW",
 		"backToOnline": "Back to Online",
 		"waitingForGame": "Waiting for game to start...",
 		"clickToStart": "Click to start controls",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -118,6 +118,7 @@
 		"controls": "Contrôles",
 		"youWin": "VICTOIRE !",
 		"youLose": "DÉFAITE",
+		"nobodyWin": "Aucun gagnant",
 		"backToOnline": "Retour en ligne",
 		"waitingForGame": "En attente du début de la partie...",
 		"clickToStart": "Cliquez pour commencer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -118,6 +118,7 @@
 		"controls": "操作方法",
 		"youWin": "勝利！",
 		"youLose": "敗北",
+		"nobodyWin": "勝者なし",
 		"backToOnline": "オンラインに戻る",
 		"waitingForGame": "ゲーム開始を待っています...",
 		"clickToStart": "クリックして操作を開始",


### PR DESCRIPTION
Issue #80「片方のみ再接続した場合の勝利メッセージが表示されない」への対応です。

再接続後のケースにおいて、以下の状況でもメッセージが正しく表示されるように修正しました：

・サレンダー時
・相手の切断による勝利時