### PR TITLE
fix: socketManager のデフォルト API URL を api.ts と統一

### DIFF
--- a/frontend/src/services/socketManager.ts
+++ b/frontend/src/services/socketManager.ts
@@ -3,8 +3,10 @@
  * HTTPクライアント(api.ts)と同じAPI_URLを使用
  */
 
-// 環境変数からAPIのURLを取得（デフォルトはlocalhost:3000）
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+// 環境変数からAPIのURLを取得
+// デフォルトは api.ts と同じ https://localhost/api で統一する
+// (VITE_API_URL が未伝搬の場合でも CSP 準拠の URL を使うフォールバック)
+const API_URL = import.meta.env.VITE_API_URL || "https://localhost/api";
 
 // WebSocket接続用のベースURL
 // REST APIは https://localhost/api だが、Socket.IOのネームスペースは /game, /chat


### PR DESCRIPTION
- VITE_API_URL 未設定時のフォールバック値を http://localhost:3000 から https://localhost/api に変更
- api.ts のデフォルト (https://localhost/api) と整合
- 本番の CSP (connect-src 'self' wss://localhost) 下でも フォールバック URL が違反を起こさないよう防御的に統一

背景:
  api.ts と socketManager.ts で || の右辺 (デフォルト) が 食い違っていたため、VITE_API_URL が未伝搬だと HTTP は動くが Socket だけ http://localhost:3000 を参照して CSP 違反になる というトリッキーな症状を起こしていた。