### PR TITLE
fix: Vault バージョン固定 (1.13.3) と SSL 証明書パーミッション修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ssl:
 			-keyout nginx/ssl/server.key \
 			-out nginx/ssl/server.crt \
 			-subj "/C=JP/ST=Tokyo/L=Tokyo/O=42Tokyo/CN=localhost"; \
+		chmod 644 nginx/ssl/server.key nginx/ssl/server.crt; \
 		echo "✅ SSL証明書を生成しました (nginx/ssl/)"; \
 		echo "⚠️  ブラウザで https://localhost を開くと警告が出ます"; \
 		echo "   「詳細設定」→「localhost にアクセスする（安全でない）」で続行できます"; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   # HashiCorp Vault（秘密情報管理）
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.13.3
     container_name: trans_vault
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## 概要

42校舎の Docker 環境で発生した2つの起動障害を修正します。

## 修正内容

### 1. Vault バージョン固定 (`docker-compose.yml`)

**変更**: `hashicorp/vault:latest` → `hashicorp/vault:1.13.3`

**原因**: `latest` タグは Vault 2.x 系を取得するが、2.x 系は起動時に Linux ケーパビリティ `CAP_SETFCAP` を要求する。42校舎の Docker 環境は seccomp/AppArmor により `CAP_SETFCAP` を許可していないため、コンテナが起動失敗する。

```
Error response from daemon: failed to create task for container:
failed to create shim task: ... cap_setfcap
```

**対応**: `CAP_SETFCAP` を必要としない `1.13.3` に固定。メンバー (fCeragio) が学校環境で実機確認済み。

### 2. SSL 証明書パーミッション修正 (`Makefile`)

**変更**: `make ssl` に `chmod 644 nginx/ssl/server.key nginx/ssl/server.crt` を追加

**原因**: `openssl` コマンドが生成する `server.key` のデフォルトパーミッションが `600` (root のみ読み取り可能) になる場合があり、nginx コンテナ (非 root ユーザー) が証明書を読めずに起動失敗する。

## 動作確認

- [x] `docker compose config` で syntax エラーなし
- [x] `make -n ssl` で `chmod 644` が正しく含まれることを確認
- [x] `hashicorp/vault:1.13.3` を `CAP_SETFCAP` なしで実際に起動確認
- [x] 全テスト 117 件パス (pre-push hook)

## 関連

- 報告者: fCeragio (学校環境での CAP_SETFCAP エラー)