### PR TITLE
fix: ChatRoom のメッセージキー衝突による React 警告を修正

### DIFF
--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -159,7 +159,7 @@ export default function ChatRoom({
 				) : (
 					messages.map((msg, index) => (
 						<ChatMessage
-							key={msg.id ?? index}
+							key={msg.id !== undefined ? `srv-${msg.id}` : `loc-${index}`}
 							message={msg}
 							isOwnMessage={msg.sender === username}
 						/>


### PR DESCRIPTION
- ChatRoom.tsx のメッセージ一覧で、サーバー由来メッセージ（id あり）と ローカル追加メッセージ（id なし・index フォールバック）の key が 衝突し「same key」警告が発生していた
- key に名前空間プレフィックスを付与（srv-<id> / loc-<index>）して 両者が衝突しないようにした

  ## Test plan                                                                                                  
  - [ ] チャットルームを開いて文字を打つ又は打った文字を送信する際にブラウザコンソールに警告が出ないことを確認  