### PR TITLE
docs: README を PR #90〜#100 の実装内容に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ _This project has been created as part of the 42 curriculum by shinji-japaaaan, 
 
 - Edit display name, bio, and avatar image _(sishizaw, alex)_
 - Friend requests / approval / list _(sishizaw, alex)_
+- Online status badge in friend list (real-time WebSocket updates) _(alex, sishizaw)_
+- View other user's profile in a modal (from friend list and DM header) _(alex)_
 
 ### Pong Game
 
@@ -75,6 +77,12 @@ _This project has been created as part of the 42 curriculum by shinji-japaaaan, 
 
 - Personal data export (JSON download) _(sishizaw, tenpapa)_
 - Account deletion (removes all associated data) _(sishizaw, tenpapa)_
+- Email notification sent on data export / account deletion _(sishizaw)_
+
+### Security / WAF
+
+- ModSecurity WAF (OWASP Core Rule Set) integrated into Nginx _(alex)_
+- Tuning rules to prevent false positives (PUT / PATCH / DELETE methods) _(alex)_
 
 ### Other
 
@@ -105,24 +113,24 @@ Major = 2 points, Minor = 1 point
 
 > **Note**: SSL/TLS, HTTPS, CSRF and XSS protections are **mandatory requirements** (Chapter III.3), not scoreable modules.
 
-| #         | Module                                                           | Type  | Points | Contributor(s)           | PDF Ref |
-| --------- | ---------------------------------------------------------------- | ----- | ------ | ------------------------ | ------- |
-| 1         | Frontend + Backend Framework (React + NestJS)                    | Major | 2      | tenpapa, alex            | IV.1    |
-| 2         | WebSocket Real-time (chat + game)                                | Major | 2      | Federico, alex           | IV.1    |
-| 3         | User Interaction (chat + profile + friends)                      | Major | 2      | Federico, alex, sishizaw | IV.1    |
-| 4         | ORM (TypeORM)                                                    | Minor | 1      | sishizaw                 | IV.1    |
-| 5         | Game Statistics and Match History                                | Minor | 1      | sishizaw, tenpapa        | IV.3    |
-| 6         | Remote Authentication (42 OAuth)                                 | Minor | 1      | alex                     | IV.3    |
-| 7         | Two-Factor Authentication (2FA)                                  | Minor | 1      | sishizaw                 | IV.3    |
-| 8         | AI Opponent (custom backend implementation with ball prediction) | Major | 2      | Federico, alex           | IV.4    |
-| 9         | Web-based Game (Pong)                                            | Major | 2      | Federico, alex           | IV.6    |
-| 10        | Remote Players (WebSocket online match)                          | Major | 2      | Federico, alex           | IV.6    |
-| 11        | Multiple Language Support (JA / EN / FR)                         | Minor | 1      | tenpapa                  | IV.2    |
-| 12        | GDPR Compliance                                                  | Minor | 1      | sishizaw, tenpapa        | IV.8    |
-| 13        | Browser Compatibility (Chrome / Firefox)                         | Minor | 1      | tenpapa                  | IV.2    |
-| **Total** |                                                                  |       | **19** |                          |         |
-
-> **Potential +2pt**: Standard User Management Major (IV.3) — profile, avatar, and friend requests are fully implemented. Once **friend online status** is added to the database, this module becomes claimable, bringing the total to 21pt.
+| #         | Module                                                                | Type  | Points | Contributor(s)           | PDF Ref |
+| --------- | --------------------------------------------------------------------- | ----- | ------ | ------------------------ | ------- |
+| 1         | Frontend + Backend Framework (React + NestJS)                         | Major | 2      | tenpapa, alex            | IV.1    |
+| 2         | WebSocket Real-time (chat + game)                                     | Major | 2      | Federico, alex           | IV.1    |
+| 3         | User Interaction (chat + profile + friends)                           | Major | 2      | Federico, alex, sishizaw | IV.1    |
+| 4         | ORM (TypeORM)                                                         | Minor | 1      | sishizaw                 | IV.1    |
+| 5         | Game Statistics and Match History                                     | Minor | 1      | sishizaw, tenpapa        | IV.3    |
+| 6         | Remote Authentication (42 OAuth)                                      | Minor | 1      | alex                     | IV.3    |
+| 7         | Two-Factor Authentication (2FA)                                       | Minor | 1      | sishizaw                 | IV.3    |
+| 8         | AI Opponent (custom backend implementation with ball prediction)      | Major | 2      | Federico, alex           | IV.4    |
+| 9         | Web-based Game (Pong)                                                 | Major | 2      | Federico, alex           | IV.6    |
+| 10        | Remote Players (WebSocket online match)                               | Major | 2      | Federico, alex           | IV.6    |
+| 11        | Multiple Language Support (JA / EN / FR)                              | Minor | 1      | tenpapa                  | IV.2    |
+| 12        | GDPR Compliance (data export, account deletion, email notification)   | Minor | 1      | sishizaw, tenpapa        | IV.8    |
+| 13        | Browser Compatibility (Chrome / Firefox)                              | Minor | 1      | tenpapa                  | IV.2    |
+| 14        | Standard User Management (profile, avatar, online status, friends)    | Major | 2      | alex, sishizaw           | IV.3    |
+| 15        | WAF Integration (ModSecurity + OWASP Core Rule Set via Nginx)         | Major | 2      | alex                     | IV.5    |
+| **Total** |                                                                       |       | **23** |                          |         |
 
 ### Module Selection Rationale
 
@@ -141,6 +149,8 @@ Major = 2 points, Minor = 1 point
 | Multiple Language Support       | French translation required for 42 Paris compatibility; Japanese/English for our team        |
 | GDPR Compliance                 | Mandatory EU data regulation; data export and account deletion are low-overhead to implement |
 | Browser Compatibility           | Ensures evaluators on any campus machine (Chrome/Firefox) can test without issues            |
+| Standard User Management        | Profile, avatar, online status, and friend list together satisfy all IV.3 Major requirements |
+| WAF / ModSecurity               | Adds an application-layer firewall (OWASP CRS) without extra services; tuned for our stack   |
 
 ### Backend Module Structure (NestJS)
 
@@ -168,13 +178,14 @@ Major = 2 points, Minor = 1 point
 
 ### Infrastructure
 
-| File                      | Role                                                               |
-| ------------------------- | ------------------------------------------------------------------ |
-| `docker-compose.yml`      | Defines 5 services (nginx / vault / postgres / backend / frontend) |
-| `nginx/nginx.conf`        | HTTPS termination and `/api` → backend reverse proxy               |
-| `Makefile`                | Aggregates dev commands: `make setup`, `make build`, etc.          |
-| `backend/src/migrations/` | TypeORM migration files                                            |
-| `shared/`                 | Type definitions and constants shared between frontend and backend |
+| File                           | Role                                                               |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `docker-compose.yml`           | Defines 5 services (nginx / vault / postgres / backend / frontend) |
+| `nginx/nginx.conf`             | HTTPS termination, `/api` → backend reverse proxy, WAF activation  |
+| `nginx/modsecurity-tuning.conf`| ModSecurity false-positive exclusions for our app                  |
+| `Makefile`                     | Aggregates dev commands: `make setup`, `make build`, etc.          |
+| `backend/src/migrations/`      | TypeORM migration files                                            |
+| `shared/`                      | Type definitions and constants shared between frontend and backend |
 
 ---
 
@@ -182,14 +193,14 @@ Major = 2 points, Minor = 1 point
 
 See [`docs/er-diagram.md`](./docs/er-diagram.md) for the full ER diagram and constraints.
 
-| Table             | Description                                                 |
-| ----------------- | ----------------------------------------------------------- |
-| `users`           | Auth info (username, password hash, 42 ID, 2FA settings)    |
-| `profiles`        | Profile info (displayName, bio, avatarUrl) — 1:1 with users |
-| `friends`         | Confirmed friend relationships                              |
-| `friend_requests` | Friend requests (pending / accepted / rejected)             |
-| `chat`            | Chat messages (per roomId)                                  |
-| `match_history`   | Match results (winnerUserId, loserUserId, scores)           |
+| Table             | Description                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| `users`           | Auth info (username, password hash, 42 ID, 2FA settings, email, is_online, last_seen_at) |
+| `profiles`        | Profile info (displayName, bio, avatarUrl) — 1:1 with users                             |
+| `friends`         | Confirmed friend relationships                                                           |
+| `friend_requests` | Friend requests (pending / accepted / rejected)                                          |
+| `chat`            | Chat messages (per roomId)                                                               |
+| `match_history`   | Match results (winnerUserId, loserUserId, scores)                                        |
 
 ```mermaid
 erDiagram
@@ -206,9 +217,11 @@ erDiagram
 
 ### sishizaw
 
-- **DB design**: ER diagram, TypeORM entity definitions, migration setup (`backend/src/migrations/`)
+- **DB design**: ER diagram, TypeORM entity definitions, migration setup (`backend/src/migrations/`); added `email`, `is_online`, `last_seen_at` columns to `users`
 - **ProfileModule**: Profile CRUD, avatar upload, XSS input validation
 - **StatsModule / GDPR backend**: Win-rate aggregation API, match history API, data export / account deletion
+- **GDPR email notification**: Created `MailModule` / `mail.service.ts`; sends confirmation email on data export and account deletion (Ethereal fallback when MAIL_HOST is unset)
+- **Online status backend**: Implemented `UserStatusService` (setOnline / setOffline), integrated with login / logout flows
 - **WebSocket auth**: JWT-based socket connection authentication fix
 - **Security**: CodeQL Path Injection fix, 2FA bug fixes (401 error, console noise), CSRF token re-fetch fix, Content-Security-Policy introduction
 
@@ -216,7 +229,9 @@ erDiagram
 
 - **Game frontend**: Updated `GamePage` for new protocol (forfeit, reconnect, mode switch with `ConfirmDialog`)
 - **Online mode**: Updated `OnlinePage`, added i18n keys for 3 languages
-- **Infrastructure**: Docker Compose, Nginx, HashiCorp Vault integration, SSL certificate setup
+- **Online status frontend**: Real-time WebSocket broadcast of status changes; online badge in friend list; view other user profile modal (from friend list and DM header)
+- **WAF / ModSecurity**: Integrated ModSecurity + OWASP CRS into Nginx (`nginx/Dockerfile`, `nginx/nginx.conf`, `nginx/modsecurity-tuning.conf`); fixed false positives for PUT / PATCH / DELETE
+- **Infrastructure**: Docker Compose, Nginx, HashiCorp Vault integration, SSL certificate setup (version pin + permission fix in PR #100)
 - **CI / Quality**: Integration test suite (`test/`), TypeORM migration auto-run, dependabot management
 - **Bootstrap migration**: Migrated all components to Bootstrap CSS framework
 
@@ -361,6 +376,10 @@ After startup, open `https://localhost` in your browser.
 | `FORTY_TWO_CALLBACK_URL`  | 42 OAuth callback URL                                   | `https://localhost/api/auth/42/callback` |
 | `VAULT_ADDR`              | Vault address                                           | `http://vault:8200`                      |
 | `VAULT_TOKEN`             | Vault token                                             | —                                        |
+| `MAIL_HOST`               | SMTP server host (leave blank to use Ethereal test)     | —                                        |
+| `MAIL_PORT`               | SMTP server port                                        | `587`                                    |
+| `MAIL_USER`               | SMTP username                                           | —                                        |
+| `MAIL_PASS`               | SMTP password                                           | —                                        |
 
 ---
 
@@ -414,6 +433,7 @@ lsof -i :5432  # PostgreSQL
 | HTTPS                    | TLS termination via Nginx                                       |
 | Two-factor auth          | Google Authenticator compatible (TOTP)                          |
 | Input validation         | NestJS DTO + class-validator                                    |
+| WAF                      | ModSecurity + OWASP Core Rule Set integrated into Nginx         |
 
 ---
 
@@ -499,6 +519,8 @@ All AI-generated code was reviewed and understood by team members before being a
 
 - 表示名・自己紹介・アバター画像の編集 _(sishizaw, alex)_
 - フレンド申請 / 承認 / 一覧表示 _(sishizaw, alex)_
+- フレンドリストへのオンラインステータスバッジ表示（WebSocket リアルタイム更新） _(alex, sishizaw)_
+- フレンド一覧・DM ヘッダーから他ユーザーのプロフィールをモーダル表示 _(alex)_
 
 ### Pong ゲーム
 
@@ -523,6 +545,12 @@ All AI-generated code was reviewed and understood by team members before being a
 
 - 個人データのエクスポート（JSON ダウンロード） _(sishizaw, tenpapa)_
 - アカウント削除（全関連データの消去） _(sishizaw, tenpapa)_
+- データエクスポート・アカウント削除時のメール通知送信 _(sishizaw)_
+
+### セキュリティ / WAF
+
+- ModSecurity WAF（OWASP Core Rule Set）を Nginx に統合 _(alex)_
+- PUT / PATCH / DELETE メソッドの誤検知（403）を除外ルールで対処 _(alex)_
 
 ### その他
 
@@ -553,24 +581,24 @@ Major = 2 ポイント、Minor = 1 ポイント
 
 > **注意**: SSL/TLS・HTTPS・CSRF/XSS 保護は Chapter III.3 の**必須要件**のため、モジュールポイントには含みません。
 
-| #        | モジュール                                                     | 種別  | ポイント | 担当                     | PDF 参照 |
-| -------- | -------------------------------------------------------------- | ----- | -------- | ------------------------ | -------- |
-| 1        | フロント + バックエンドフレームワーク（React + NestJS）        | Major | 2        | tenpapa, alex            | IV.1     |
-| 2        | WebSocket リアルタイム通信（チャット + ゲーム）                | Major | 2        | Federico, alex           | IV.1     |
-| 3        | ユーザーインタラクション（チャット + プロフィール + フレンド） | Major | 2        | Federico, alex, sishizaw | IV.1     |
-| 4        | ORM（TypeORM）                                                 | Minor | 1        | sishizaw                 | IV.1     |
-| 5        | ゲーム統計・マッチ履歴                                         | Minor | 1        | sishizaw, tenpapa        | IV.3     |
-| 6        | リモート認証（42 OAuth）                                       | Minor | 1        | alex                     | IV.3     |
-| 7        | 2FA（二要素認証）                                              | Minor | 1        | sishizaw                 | IV.3     |
-| 8        | AI 対戦相手（バックエンド自前実装・ボール軌道予測付き）        | Major | 2        | Federico, alex           | IV.4     |
-| 9        | ゲーム実装（Pong）                                             | Major | 2        | Federico, alex           | IV.6     |
-| 10       | リモートプレイヤー（WebSocket オンライン対戦）                 | Major | 2        | Federico, alex           | IV.6     |
-| 11       | 多言語対応（日 / 英 / 仏）                                     | Minor | 1        | tenpapa                  | IV.2     |
-| 12       | GDPR 対応                                                      | Minor | 1        | sishizaw, tenpapa        | IV.8     |
-| 13       | ブラウザ互換性（Chrome / Firefox）                             | Minor | 1        | tenpapa                  | IV.2     |
-| **合計** |                                                                |       | **19**   |                          |          |
-
-> **今後 +2pt の余地**: 標準ユーザー管理 Major（IV.3）はプロフィール・アバター・フレンド申請を実装済み。**フレンドのオンラインステータス表示**を追加すれば計 21pt となる予定。
+| #        | モジュール                                                                         | 種別  | ポイント | 担当                     | PDF 参照 |
+| -------- | ---------------------------------------------------------------------------------- | ----- | -------- | ------------------------ | -------- |
+| 1        | フロント + バックエンドフレームワーク（React + NestJS）                            | Major | 2        | tenpapa, alex            | IV.1     |
+| 2        | WebSocket リアルタイム通信（チャット + ゲーム）                                    | Major | 2        | Federico, alex           | IV.1     |
+| 3        | ユーザーインタラクション（チャット + プロフィール + フレンド）                     | Major | 2        | Federico, alex, sishizaw | IV.1     |
+| 4        | ORM（TypeORM）                                                                     | Minor | 1        | sishizaw                 | IV.1     |
+| 5        | ゲーム統計・マッチ履歴                                                             | Minor | 1        | sishizaw, tenpapa        | IV.3     |
+| 6        | リモート認証（42 OAuth）                                                           | Minor | 1        | alex                     | IV.3     |
+| 7        | 2FA（二要素認証）                                                                  | Minor | 1        | sishizaw                 | IV.3     |
+| 8        | AI 対戦相手（バックエンド自前実装・ボール軌道予測付き）                            | Major | 2        | Federico, alex           | IV.4     |
+| 9        | ゲーム実装（Pong）                                                                 | Major | 2        | Federico, alex           | IV.6     |
+| 10       | リモートプレイヤー（WebSocket オンライン対戦）                                     | Major | 2        | Federico, alex           | IV.6     |
+| 11       | 多言語対応（日 / 英 / 仏）                                                         | Minor | 1        | tenpapa                  | IV.2     |
+| 12       | GDPR 対応（データエクスポート・アカウント削除・メール通知）                         | Minor | 1        | sishizaw, tenpapa        | IV.8     |
+| 13       | ブラウザ互換性（Chrome / Firefox）                                                 | Minor | 1        | tenpapa                  | IV.2     |
+| 14       | 標準ユーザー管理（プロフィール・アバター・オンラインステータス・フレンド）          | Major | 2        | alex, sishizaw           | IV.3     |
+| 15       | WAF 統合（ModSecurity + OWASP Core Rule Set）                                      | Major | 2        | alex                     | IV.5     |
+| **合計** |                                                                                    |       | **23**   |                          |          |
 
 ### モジュール選定理由
 
@@ -589,6 +617,8 @@ Major = 2 ポイント、Minor = 1 ポイント
 | 多言語対応                       | 42 Paris の評価者向けにフランス語が必要。日本語・英語はチームの使用言語                  |
 | GDPR 対応                        | EU データ規制への対応。データエクスポート・削除は低コストで実装可能                      |
 | ブラウザ互換性                   | 評価者がどのキャンパスのマシン（Chrome/Firefox）でもテストできるように確保               |
+| 標準ユーザー管理                 | プロフィール・アバター・オンラインステータス・フレンドリストで IV.3 Major の全要件を充足  |
+| WAF / ModSecurity               | Nginx に OWASP CRS を統合。追加サービス不要で WAF 要件を満たし、誤検知は除外ルールで対処 |
 
 ### バックエンドモジュール構成（NestJS）
 
@@ -616,13 +646,14 @@ Major = 2 ポイント、Minor = 1 ポイント
 
 ### インフラ
 
-| ファイル                  | 役割                                                              |
-| ------------------------- | ----------------------------------------------------------------- |
-| `docker-compose.yml`      | 5 サービス（nginx / vault / postgres / backend / frontend）の定義 |
-| `nginx/nginx.conf`        | HTTPS 終端・`/api` → バックエンドへのリバースプロキシ             |
-| `Makefile`                | `make setup` / `make build` など開発用コマンドの集約              |
-| `backend/src/migrations/` | TypeORM マイグレーションファイル                                  |
-| `shared/`                 | フロントエンド・バックエンド共通の型定義・定数                    |
+| ファイル                          | 役割                                                              |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `docker-compose.yml`              | 5 サービス（nginx / vault / postgres / backend / frontend）の定義 |
+| `nginx/nginx.conf`                | HTTPS 終端・`/api` → バックエンドへのリバースプロキシ・WAF 有効化 |
+| `nginx/modsecurity-tuning.conf`   | ModSecurity 誤検知除外ルール（アプリ固有チューニング）            |
+| `Makefile`                        | `make setup` / `make build` など開発用コマンドの集約              |
+| `backend/src/migrations/`         | TypeORM マイグレーションファイル                                  |
+| `shared/`                         | フロントエンド・バックエンド共通の型定義・定数                    |
 
 ---
 
@@ -630,14 +661,14 @@ Major = 2 ポイント、Minor = 1 ポイント
 
 詳細は [`docs/er-diagram.md`](./docs/er-diagram.md) を参照してください。
 
-| テーブル          | 説明                                                             |
-| ----------------- | ---------------------------------------------------------------- |
-| `users`           | 認証情報（username, password hash, 42 ID, 2FA 設定）             |
-| `profiles`        | プロフィール情報（displayName, bio, avatarUrl）— users と 1 対 1 |
-| `friends`         | 承認済みフレンド関係                                             |
-| `friend_requests` | フレンド申請（pending / accepted / rejected）                    |
-| `chat`            | チャットメッセージ（roomId 単位）                                |
-| `match_history`   | 対戦履歴（winnerUserId, loserUserId, スコア）                    |
+| テーブル          | 説明                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| `users`           | 認証情報（username, password hash, 42 ID, 2FA 設定, email, is_online, last_seen_at）             |
+| `profiles`        | プロフィール情報（displayName, bio, avatarUrl）— users と 1 対 1                                |
+| `friends`         | 承認済みフレンド関係                                                                             |
+| `friend_requests` | フレンド申請（pending / accepted / rejected）                                                    |
+| `chat`            | チャットメッセージ（roomId 単位）                                                                |
+| `match_history`   | 対戦履歴（winnerUserId, loserUserId, スコア）                                                    |
 
 ```mermaid
 erDiagram
@@ -654,9 +685,11 @@ erDiagram
 
 ### sishizaw
 
-- **DB 設計**: ER 図作成・TypeORM エンティティ定義・マイグレーション整備（`backend/src/migrations/`）
+- **DB 設計**: ER 図作成・TypeORM エンティティ定義・マイグレーション整備（`backend/src/migrations/`）; `email` / `is_online` / `last_seen_at` カラムを `users` に追加
 - **ProfileModule**: プロフィール CRUD・アバターアップロード・XSS バリデーション追加
 - **StatsModule / GDPR バックエンド**: 勝率集計 API・試合履歴 API・データエクスポート / アカウント削除実装
+- **GDPR メール通知**: `MailModule` / `mail.service.ts` を新規作成；データエクスポート・アカウント削除時にメール送信（MAIL_HOST 未設定時は Ethereal テストアカウントで自動動作）
+- **オンラインステータス バックエンド**: `UserStatusService`（setOnline / setOffline）を実装；ログイン・ログアウト処理に統合
 - **WebSocket 認証**: JWT によるソケット接続の認証修正
 - **セキュリティ**: CodeQL 指摘の Path Injection 修正、2FA バグ修正（401 エラー・コンソールノイズ除去）、CSRF トークン再取得問題の修正、Content-Security-Policy 導入
 
@@ -664,7 +697,9 @@ erDiagram
 
 - **ゲームフロントエンド**: `GamePage` を新プロトコルに対応（降参・再接続・モード切替確認ダイアログ）、`ConfirmDialog` コンポーネント作成
 - **オンラインモード**: `OnlinePage` 更新、i18n キー追加（3 言語対応）
-- **インフラ**: Docker Compose・Nginx・HashiCorp Vault 統合・SSL 証明書設定
+- **オンラインステータス フロントエンド**: ステータス変化を WebSocket でリアルタイム配信；フレンドリストにオンラインバッジを表示；フレンド一覧・DM ヘッダーから他ユーザーのプロフィールをモーダル表示
+- **WAF / ModSecurity**: ModSecurity + OWASP CRS を Nginx に統合（`nginx/Dockerfile`・`nginx/nginx.conf`・`nginx/modsecurity-tuning.conf`）；PUT / PATCH / DELETE の誤検知（403）を除外ルールで修正
+- **インフラ**: Docker Compose・Nginx・HashiCorp Vault 統合・SSL 証明書設定（PR #100 でバージョン固定とパーミッション修正）
 - **CI / 品質**: 統合テストスイート追加（`test/`）、TypeORM マイグレーション自動実行、dependabot 管理
 - **Bootstrap 移行**: 全コンポーネントの CSS フレームワーク移行
 
@@ -811,6 +846,10 @@ make build
 | `FORTY_TWO_CALLBACK_URL`  | 42 OAuth コールバック URL                        | `https://localhost/api/auth/42/callback` |
 | `VAULT_ADDR`              | Vault アドレス                                   | `http://vault:8200`                      |
 | `VAULT_TOKEN`             | Vault トークン                                   | —                                        |
+| `MAIL_HOST`               | SMTP サーバーホスト（未設定時は Ethereal 自動生成） | —                                       |
+| `MAIL_PORT`               | SMTP サーバーポート                              | `587`                                    |
+| `MAIL_USER`               | SMTP ユーザー名                                  | —                                        |
+| `MAIL_PASS`               | SMTP パスワード                                  | —                                        |
 
 ---
 
@@ -864,6 +903,7 @@ lsof -i :5432  # PostgreSQL
 | HTTPS                    | Nginx による TLS 終端                                                           |
 | 二要素認証               | Google Authenticator 対応（TOTP）                                               |
 | 入力バリデーション       | NestJS DTO + class-validator                                                    |
+| WAF                      | ModSecurity + OWASP Core Rule Set を Nginx に統合                               |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ _This project has been created as part of the 42 curriculum by shinji-japaaaan, 
 | Real-time         | WebSocket (Socket.IO)                        | Game and chat                        |
 | Auth              | JWT (Passport.js) + Google Authenticator 2FA | Cookie-based                         |
 | Reverse proxy     | Nginx                                        | HTTPS termination and routing        |
-| Secret management | HashiCorp Vault                              | Dev mode in development environment  |
+| Secret management | HashiCorp Vault                              | Manages credentials and env secrets  |
 | Containerization  | Docker + Docker Compose                      | All services managed together        |
 
 ---
@@ -574,7 +574,7 @@ All AI-generated code was reviewed and understood by team members before being a
 | リアルタイム通信 | WebSocket（Socket.IO）                            | ゲーム・チャット                      |
 | 認証             | JWT (Passport.js) + Google Authenticator 対応 2FA | Cookie ベース                         |
 | リバースプロキシ | Nginx                                             | HTTPS 終端・ルーティング              |
-| 秘密情報管理     | HashiCorp Vault                                   | 開発環境では dev モード               |
+| 秘密情報管理     | HashiCorp Vault                                   | クレデンシャル・環境変数を一元管理    |
 | コンテナ         | Docker + Docker Compose                           | 全サービス一括管理                    |
 
 ---

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Major = 2 points, Minor = 1 point
 | 12        | GDPR Compliance (data export, account deletion, email notification)   | Minor | 1      | sishizaw, tenpapa        | IV.8    |
 | 13        | Browser Compatibility (Chrome / Firefox)                              | Minor | 1      | tenpapa                  | IV.2    |
 | 14        | Standard User Management (profile, avatar, online status, friends)    | Major | 2      | alex, sishizaw           | IV.3    |
-| 15        | WAF Integration (ModSecurity + OWASP Core Rule Set via Nginx)         | Major | 2      | alex                     | IV.5    |
+| 15        | WAF + Secret Management (ModSecurity + OWASP CRS / HashiCorp Vault)   | Major | 2      | sishizaw                 | IV.5    |
 | **Total** |                                                                       |       | **23** |                          |         |
 
 ### Module Selection Rationale
@@ -150,7 +150,7 @@ Major = 2 points, Minor = 1 point
 | GDPR Compliance                 | Mandatory EU data regulation; data export and account deletion are low-overhead to implement |
 | Browser Compatibility           | Ensures evaluators on any campus machine (Chrome/Firefox) can test without issues            |
 | Standard User Management        | Profile, avatar, online status, and friend list together satisfy all IV.3 Major requirements |
-| WAF / ModSecurity               | Adds an application-layer firewall (OWASP CRS) without extra services; tuned for our stack   |
+| WAF + Vault (IV.5)              | ModSecurity/OWASP CRS blocks common attacks; Vault already manages all secrets — together they satisfy the single IV.5 Major requirement |
 
 ### Backend Module Structure (NestJS)
 
@@ -220,8 +220,10 @@ erDiagram
 - **DB design**: ER diagram, TypeORM entity definitions, migration setup (`backend/src/migrations/`); added `email`, `is_online`, `last_seen_at` columns to `users`
 - **ProfileModule**: Profile CRUD, avatar upload, XSS input validation
 - **StatsModule / GDPR backend**: Win-rate aggregation API, match history API, data export / account deletion
-- **GDPR email notification**: Created `MailModule` / `mail.service.ts`; sends confirmation email on data export and account deletion (Ethereal fallback when MAIL_HOST is unset)
-- **Online status backend**: Implemented `UserStatusService` (setOnline / setOffline), integrated with login / logout flows
+- **GDPR email notification**: Created `MailModule` / `mail.service.ts`; sends confirmation email on data export and account deletion (Ethereal fallback when MAIL_HOST is unset) (`5c73a36`)
+- **Online status backend**: Added `is_online` / `last_seen_at` to `users` entity and migration; implemented `UserStatusService` (setOnline / setOffline) (`b44c93e`); refactored backend responsibility (`cb032b4`)
+- **WAF / ModSecurity**: Integrated ModSecurity + OWASP CRS into Nginx (`nginx/Dockerfile`, `nginx/modsecurity-tuning.conf`) (`6ac1f83`); fixed false positives for PUT / PATCH / DELETE (`49829b9`); added Nginx `/healthz` endpoint (`05ae20d`)
+- **Vault**: Version pin and SSL certificate permission fix (`c2a3c3b`); migration consolidation (`e0bb68a`)
 - **WebSocket auth**: JWT-based socket connection authentication fix
 - **Security**: CodeQL Path Injection fix, 2FA bug fixes (401 error, console noise), CSRF token re-fetch fix, Content-Security-Policy introduction
 
@@ -229,9 +231,9 @@ erDiagram
 
 - **Game frontend**: Updated `GamePage` for new protocol (forfeit, reconnect, mode switch with `ConfirmDialog`)
 - **Online mode**: Updated `OnlinePage`, added i18n keys for 3 languages
-- **Online status frontend**: Real-time WebSocket broadcast of status changes; online badge in friend list; view other user profile modal (from friend list and DM header)
-- **WAF / ModSecurity**: Integrated ModSecurity + OWASP CRS into Nginx (`nginx/Dockerfile`, `nginx/nginx.conf`, `nginx/modsecurity-tuning.conf`); fixed false positives for PUT / PATCH / DELETE
-- **Infrastructure**: Docker Compose, Nginx, HashiCorp Vault integration, SSL certificate setup (version pin + permission fix in PR #100)
+- **Online status frontend**: Real-time WebSocket broadcast of status changes (`f85a812`); DB-centralized status with login/logout integration (`73f44db`); online badge in friend list (`1906f29`)
+- **View other user profile**: Modal display from friend list (`f05f0ea`) and DM header (`cf8ead9`)
+- **Infrastructure**: Docker Compose, Nginx, HashiCorp Vault integration, SSL certificate setup; dev-environment `/@fs/` 403 fix (`e5b4fd4`)
 - **CI / Quality**: Integration test suite (`test/`), TypeORM migration auto-run, dependabot management
 - **Bootstrap migration**: Migrated all components to Bootstrap CSS framework
 
@@ -248,6 +250,7 @@ erDiagram
 - **Game backend foundation**: Built WebSocket gateway, game logic, and AI mode from scratch (`game.gateway.ts` / `game.service.ts`)
 - **AI difficulty**: Tuned AI to behave more human-like; unified difficulty/delay relationship
 - **Reconnection & disconnect handling**: Backend auto-detection of reconnect, match invalidation on both-player disconnect, forfeit handling after opponent disconnect
+- **Game message fixes (PR #93)**: Correct game-over + message when reconnected player wins on grace-time expiry (`e7ddaad`); "waiting for opponent reconnect" message shown to reconnected player too (`844b45b`); unified cancel message for both players (`ea9a835`)
 - **Shared design**: Extracted common constants (`GRACE_TIME`, etc.) and GameState DTOs into `shared/`
 
 ---
@@ -433,7 +436,8 @@ lsof -i :5432  # PostgreSQL
 | HTTPS                    | TLS termination via Nginx                                       |
 | Two-factor auth          | Google Authenticator compatible (TOTP)                          |
 | Input validation         | NestJS DTO + class-validator                                    |
-| WAF                      | ModSecurity + OWASP Core Rule Set integrated into Nginx         |
+| WAF                      | ModSecurity + OWASP Core Rule Set integrated into Nginx (IV.5)  |
+| Secret management        | HashiCorp Vault manages all credentials and env secrets (IV.5)  |
 
 ---
 
@@ -597,7 +601,7 @@ Major = 2 ポイント、Minor = 1 ポイント
 | 12       | GDPR 対応（データエクスポート・アカウント削除・メール通知）                         | Minor | 1        | sishizaw, tenpapa        | IV.8     |
 | 13       | ブラウザ互換性（Chrome / Firefox）                                                 | Minor | 1        | tenpapa                  | IV.2     |
 | 14       | 標準ユーザー管理（プロフィール・アバター・オンラインステータス・フレンド）          | Major | 2        | alex, sishizaw           | IV.3     |
-| 15       | WAF 統合（ModSecurity + OWASP Core Rule Set）                                      | Major | 2        | alex                     | IV.5     |
+| 15       | WAF + 秘密情報管理（ModSecurity + OWASP CRS / HashiCorp Vault）                    | Major | 2        | sishizaw                 | IV.5     |
 | **合計** |                                                                                    |       | **23**   |                          |          |
 
 ### モジュール選定理由
@@ -618,7 +622,7 @@ Major = 2 ポイント、Minor = 1 ポイント
 | GDPR 対応                        | EU データ規制への対応。データエクスポート・削除は低コストで実装可能                      |
 | ブラウザ互換性                   | 評価者がどのキャンパスのマシン（Chrome/Firefox）でもテストできるように確保               |
 | 標準ユーザー管理                 | プロフィール・アバター・オンラインステータス・フレンドリストで IV.3 Major の全要件を充足  |
-| WAF / ModSecurity               | Nginx に OWASP CRS を統合。追加サービス不要で WAF 要件を満たし、誤検知は除外ルールで対処 |
+| WAF + Vault (IV.5)              | ModSecurity/OWASP CRS で一般的な攻撃をブロック、Vault で全シークレットを管理。両方の組み合わせで IV.5 Major 1つを充足 |
 
 ### バックエンドモジュール構成（NestJS）
 
@@ -688,8 +692,10 @@ erDiagram
 - **DB 設計**: ER 図作成・TypeORM エンティティ定義・マイグレーション整備（`backend/src/migrations/`）; `email` / `is_online` / `last_seen_at` カラムを `users` に追加
 - **ProfileModule**: プロフィール CRUD・アバターアップロード・XSS バリデーション追加
 - **StatsModule / GDPR バックエンド**: 勝率集計 API・試合履歴 API・データエクスポート / アカウント削除実装
-- **GDPR メール通知**: `MailModule` / `mail.service.ts` を新規作成；データエクスポート・アカウント削除時にメール送信（MAIL_HOST 未設定時は Ethereal テストアカウントで自動動作）
-- **オンラインステータス バックエンド**: `UserStatusService`（setOnline / setOffline）を実装；ログイン・ログアウト処理に統合
+- **GDPR メール通知**: `MailModule` / `mail.service.ts` を新規作成；データエクスポート・アカウント削除時にメール送信（MAIL_HOST 未設定時は Ethereal テストアカウントで自動動作）(`5c73a36`)
+- **オンラインステータス バックエンド**: `is_online` / `last_seen_at` を `users` エンティティとマイグレーションに追加；`UserStatusService`（setOnline / setOffline）を実装 (`b44c93e`)；バックエンド責務をリファクタリング (`cb032b4`)
+- **WAF / ModSecurity**: ModSecurity + OWASP CRS を Nginx に統合（`nginx/Dockerfile`・`nginx/modsecurity-tuning.conf`）(`6ac1f83`)；PUT / PATCH / DELETE の誤検知を除外ルールで修正 (`49829b9`)；Nginx `/healthz` エンドポイント追加 (`05ae20d`)
+- **Vault**: バージョン固定と SSL 証明書パーミッション修正 (`c2a3c3b`)；マイグレーションを1ファイルに統合 (`e0bb68a`)
 - **WebSocket 認証**: JWT によるソケット接続の認証修正
 - **セキュリティ**: CodeQL 指摘の Path Injection 修正、2FA バグ修正（401 エラー・コンソールノイズ除去）、CSRF トークン再取得問題の修正、Content-Security-Policy 導入
 
@@ -697,9 +703,9 @@ erDiagram
 
 - **ゲームフロントエンド**: `GamePage` を新プロトコルに対応（降参・再接続・モード切替確認ダイアログ）、`ConfirmDialog` コンポーネント作成
 - **オンラインモード**: `OnlinePage` 更新、i18n キー追加（3 言語対応）
-- **オンラインステータス フロントエンド**: ステータス変化を WebSocket でリアルタイム配信；フレンドリストにオンラインバッジを表示；フレンド一覧・DM ヘッダーから他ユーザーのプロフィールをモーダル表示
-- **WAF / ModSecurity**: ModSecurity + OWASP CRS を Nginx に統合（`nginx/Dockerfile`・`nginx/nginx.conf`・`nginx/modsecurity-tuning.conf`）；PUT / PATCH / DELETE の誤検知（403）を除外ルールで修正
-- **インフラ**: Docker Compose・Nginx・HashiCorp Vault 統合・SSL 証明書設定（PR #100 でバージョン固定とパーミッション修正）
+- **オンラインステータス フロントエンド**: ステータス変化を WebSocket でリアルタイム配信 (`f85a812`)；DB 一元化とログイン契機更新 (`73f44db`)；フレンドリストにオンラインバッジを表示 (`1906f29`)
+- **他ユーザープロフィール表示**: フレンド一覧からモーダル表示 (`f05f0ea`)；DM ヘッダーからモーダル表示 (`cf8ead9`)
+- **インフラ**: Docker Compose・Nginx・HashiCorp Vault 統合・SSL 証明書設定；dev 環境 `/@fs/` 403 修正 (`e5b4fd4`)
 - **CI / 品質**: 統合テストスイート追加（`test/`）、TypeORM マイグレーション自動実行、dependabot 管理
 - **Bootstrap 移行**: 全コンポーネントの CSS フレームワーク移行
 
@@ -716,6 +722,7 @@ erDiagram
 - **ゲームバックエンド基盤**: WebSocket ゲートウェイ・ゲームロジック・AI モードをゼロから実装（`game.gateway.ts` / `game.service.ts`）
 - **AI 難易度**: 人間らしい動作に調整、difficulty と delay の関係を統一
 - **再接続・切断処理**: 再接続をバックエンド自動判定に変更、両プレイヤー切断時の試合無効化、相手切断後の降参処理
+- **ゲームメッセージ修正 (PR #93)**: 再接続プレイヤーが猶予時間切れで勝った際の正常なゲームオーバー表示 (`e7ddaad`)；再接続プレイヤーへの「相手の再接続待ち」メッセージ表示 (`844b45b`)；試合キャンセル時のメッセージ統一 (`ea9a835`)
 - **shared 設計**: `GRACE_TIME` 等の共通定数・GameState DTO を `shared/` に分離
 
 ---
@@ -903,7 +910,8 @@ lsof -i :5432  # PostgreSQL
 | HTTPS                    | Nginx による TLS 終端                                                           |
 | 二要素認証               | Google Authenticator 対応（TOTP）                                               |
 | 入力バリデーション       | NestJS DTO + class-validator                                                    |
-| WAF                      | ModSecurity + OWASP Core Rule Set を Nginx に統合                               |
+| WAF                      | ModSecurity + OWASP Core Rule Set を Nginx に統合（IV.5）                       |
+| 秘密情報管理             | HashiCorp Vault で全クレデンシャル・環境変数を管理（IV.5）                      |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ _This project has been created as part of the 42 curriculum by shinji-japaaaan, 
 
 ### Security / WAF
 
-- ModSecurity WAF (OWASP Core Rule Set) integrated into Nginx _(alex)_
-- Tuning rules to prevent false positives (PUT / PATCH / DELETE methods) _(alex)_
+- ModSecurity WAF (OWASP Core Rule Set) integrated into Nginx _(sishizaw)_
+- Tuning rules to prevent false positives (PUT / PATCH / DELETE methods) _(sishizaw)_
 
 ### Other
 
@@ -220,10 +220,10 @@ erDiagram
 - **DB design**: ER diagram, TypeORM entity definitions, migration setup (`backend/src/migrations/`); added `email`, `is_online`, `last_seen_at` columns to `users`
 - **ProfileModule**: Profile CRUD, avatar upload, XSS input validation
 - **StatsModule / GDPR backend**: Win-rate aggregation API, match history API, data export / account deletion
-- **GDPR email notification**: Created `MailModule` / `mail.service.ts`; sends confirmation email on data export and account deletion (Ethereal fallback when MAIL_HOST is unset) (`5c73a36`)
-- **Online status backend**: Added `is_online` / `last_seen_at` to `users` entity and migration; implemented `UserStatusService` (setOnline / setOffline) (`b44c93e`); refactored backend responsibility (`cb032b4`)
-- **WAF / ModSecurity**: Integrated ModSecurity + OWASP CRS into Nginx (`nginx/Dockerfile`, `nginx/modsecurity-tuning.conf`) (`6ac1f83`); fixed false positives for PUT / PATCH / DELETE (`49829b9`); added Nginx `/healthz` endpoint (`05ae20d`)
-- **Vault**: Version pin and SSL certificate permission fix (`c2a3c3b`); migration consolidation (`e0bb68a`)
+- **GDPR email notification**: Created `MailModule` / `mail.service.ts`; sends confirmation email on data export and account deletion (Ethereal fallback when MAIL_HOST is unset)
+- **Online status backend**: Added `is_online` / `last_seen_at` to `users` entity and migration; implemented `UserStatusService` (setOnline / setOffline); refactored backend responsibility
+- **WAF / ModSecurity**: Integrated ModSecurity + OWASP CRS into Nginx (`nginx/Dockerfile`, `nginx/modsecurity-tuning.conf`); fixed false positives for PUT / PATCH / DELETE; added Nginx `/healthz` endpoint
+- **Vault**: Version pin and SSL certificate permission fix; migration consolidation
 - **WebSocket auth**: JWT-based socket connection authentication fix
 - **Security**: CodeQL Path Injection fix, 2FA bug fixes (401 error, console noise), CSRF token re-fetch fix, Content-Security-Policy introduction
 
@@ -231,9 +231,9 @@ erDiagram
 
 - **Game frontend**: Updated `GamePage` for new protocol (forfeit, reconnect, mode switch with `ConfirmDialog`)
 - **Online mode**: Updated `OnlinePage`, added i18n keys for 3 languages
-- **Online status frontend**: Real-time WebSocket broadcast of status changes (`f85a812`); DB-centralized status with login/logout integration (`73f44db`); online badge in friend list (`1906f29`)
-- **View other user profile**: Modal display from friend list (`f05f0ea`) and DM header (`cf8ead9`)
-- **Infrastructure**: Docker Compose, Nginx, HashiCorp Vault integration, SSL certificate setup; dev-environment `/@fs/` 403 fix (`e5b4fd4`)
+- **Online status frontend**: Real-time WebSocket broadcast of status changes; DB-centralized status with login/logout integration; online badge in friend list
+- **View other user profile**: Modal display from friend list and DM header
+- **Infrastructure**: Docker Compose, Nginx, HashiCorp Vault integration, SSL certificate setup; dev-environment `/@fs/` 403 fix
 - **CI / Quality**: Integration test suite (`test/`), TypeORM migration auto-run, dependabot management
 - **Bootstrap migration**: Migrated all components to Bootstrap CSS framework
 
@@ -250,7 +250,7 @@ erDiagram
 - **Game backend foundation**: Built WebSocket gateway, game logic, and AI mode from scratch (`game.gateway.ts` / `game.service.ts`)
 - **AI difficulty**: Tuned AI to behave more human-like; unified difficulty/delay relationship
 - **Reconnection & disconnect handling**: Backend auto-detection of reconnect, match invalidation on both-player disconnect, forfeit handling after opponent disconnect
-- **Game message fixes (PR #93)**: Correct game-over + message when reconnected player wins on grace-time expiry (`e7ddaad`); "waiting for opponent reconnect" message shown to reconnected player too (`844b45b`); unified cancel message for both players (`ea9a835`)
+- **Game message fixes (PR #93)**: Correct game-over and message when reconnected player wins on grace-time expiry; "waiting for opponent reconnect" message shown to reconnected player too; unified cancel message for both players
 - **Shared design**: Extracted common constants (`GRACE_TIME`, etc.) and GameState DTOs into `shared/`
 
 ---
@@ -553,8 +553,8 @@ All AI-generated code was reviewed and understood by team members before being a
 
 ### セキュリティ / WAF
 
-- ModSecurity WAF（OWASP Core Rule Set）を Nginx に統合 _(alex)_
-- PUT / PATCH / DELETE メソッドの誤検知（403）を除外ルールで対処 _(alex)_
+- ModSecurity WAF（OWASP Core Rule Set）を Nginx に統合 _(sishizaw)_
+- PUT / PATCH / DELETE メソッドの誤検知（403）を除外ルールで対処 _(sishizaw)_
 
 ### その他
 
@@ -692,10 +692,10 @@ erDiagram
 - **DB 設計**: ER 図作成・TypeORM エンティティ定義・マイグレーション整備（`backend/src/migrations/`）; `email` / `is_online` / `last_seen_at` カラムを `users` に追加
 - **ProfileModule**: プロフィール CRUD・アバターアップロード・XSS バリデーション追加
 - **StatsModule / GDPR バックエンド**: 勝率集計 API・試合履歴 API・データエクスポート / アカウント削除実装
-- **GDPR メール通知**: `MailModule` / `mail.service.ts` を新規作成；データエクスポート・アカウント削除時にメール送信（MAIL_HOST 未設定時は Ethereal テストアカウントで自動動作）(`5c73a36`)
-- **オンラインステータス バックエンド**: `is_online` / `last_seen_at` を `users` エンティティとマイグレーションに追加；`UserStatusService`（setOnline / setOffline）を実装 (`b44c93e`)；バックエンド責務をリファクタリング (`cb032b4`)
-- **WAF / ModSecurity**: ModSecurity + OWASP CRS を Nginx に統合（`nginx/Dockerfile`・`nginx/modsecurity-tuning.conf`）(`6ac1f83`)；PUT / PATCH / DELETE の誤検知を除外ルールで修正 (`49829b9`)；Nginx `/healthz` エンドポイント追加 (`05ae20d`)
-- **Vault**: バージョン固定と SSL 証明書パーミッション修正 (`c2a3c3b`)；マイグレーションを1ファイルに統合 (`e0bb68a`)
+- **GDPR メール通知**: `MailModule` / `mail.service.ts` を新規作成；データエクスポート・アカウント削除時にメール送信（MAIL_HOST 未設定時は Ethereal テストアカウントで自動動作）
+- **オンラインステータス バックエンド**: `is_online` / `last_seen_at` を `users` エンティティとマイグレーションに追加；`UserStatusService`（setOnline / setOffline）を実装；バックエンド責務をリファクタリング
+- **WAF / ModSecurity**: ModSecurity + OWASP CRS を Nginx に統合（`nginx/Dockerfile`・`nginx/modsecurity-tuning.conf`）；PUT / PATCH / DELETE の誤検知を除外ルールで修正；Nginx `/healthz` エンドポイント追加
+- **Vault**: バージョン固定と SSL 証明書パーミッション修正；マイグレーションを1ファイルに統合
 - **WebSocket 認証**: JWT によるソケット接続の認証修正
 - **セキュリティ**: CodeQL 指摘の Path Injection 修正、2FA バグ修正（401 エラー・コンソールノイズ除去）、CSRF トークン再取得問題の修正、Content-Security-Policy 導入
 
@@ -703,9 +703,9 @@ erDiagram
 
 - **ゲームフロントエンド**: `GamePage` を新プロトコルに対応（降参・再接続・モード切替確認ダイアログ）、`ConfirmDialog` コンポーネント作成
 - **オンラインモード**: `OnlinePage` 更新、i18n キー追加（3 言語対応）
-- **オンラインステータス フロントエンド**: ステータス変化を WebSocket でリアルタイム配信 (`f85a812`)；DB 一元化とログイン契機更新 (`73f44db`)；フレンドリストにオンラインバッジを表示 (`1906f29`)
-- **他ユーザープロフィール表示**: フレンド一覧からモーダル表示 (`f05f0ea`)；DM ヘッダーからモーダル表示 (`cf8ead9`)
-- **インフラ**: Docker Compose・Nginx・HashiCorp Vault 統合・SSL 証明書設定；dev 環境 `/@fs/` 403 修正 (`e5b4fd4`)
+- **オンラインステータス フロントエンド**: ステータス変化を WebSocket でリアルタイム配信；DB 一元化とログイン契機更新；フレンドリストにオンラインバッジを表示
+- **他ユーザープロフィール表示**: フレンド一覧からモーダル表示；DM ヘッダーからモーダル表示
+- **インフラ**: Docker Compose・Nginx・HashiCorp Vault 統合・SSL 証明書設定；dev 環境 `/@fs/` 403 修正
 - **CI / 品質**: 統合テストスイート追加（`test/`）、TypeORM マイグレーション自動実行、dependabot 管理
 - **Bootstrap 移行**: 全コンポーネントの CSS フレームワーク移行
 
@@ -722,7 +722,7 @@ erDiagram
 - **ゲームバックエンド基盤**: WebSocket ゲートウェイ・ゲームロジック・AI モードをゼロから実装（`game.gateway.ts` / `game.service.ts`）
 - **AI 難易度**: 人間らしい動作に調整、difficulty と delay の関係を統一
 - **再接続・切断処理**: 再接続をバックエンド自動判定に変更、両プレイヤー切断時の試合無効化、相手切断後の降参処理
-- **ゲームメッセージ修正 (PR #93)**: 再接続プレイヤーが猶予時間切れで勝った際の正常なゲームオーバー表示 (`e7ddaad`)；再接続プレイヤーへの「相手の再接続待ち」メッセージ表示 (`844b45b`)；試合キャンセル時のメッセージ統一 (`ea9a835`)
+- **ゲームメッセージ修正 (PR #93)**: 再接続プレイヤーが猶予時間切れで勝った際の正常なゲームオーバー表示；再接続プレイヤーへの「相手の再接続待ち」メッセージ表示；試合キャンセル時のメッセージ統一
 - **shared 設計**: `GRACE_TIME` 等の共通定数・GameState DTO を `shared/` に分離
 
 ---

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -4,7 +4,7 @@
 
 | テーブル名        | 対応 Entity     | 説明                              |
 | ----------------- | --------------- | --------------------------------- |
-| `users`           | `User`          | 認証情報・アカウント              |
+| `users`           | `User`          | 認証情報・アカウント（email / is_online / last_seen_at 追加済み） |
 | `profiles`        | `Profile`       | プロフィール情報（users と 1対1） |
 | `friends`         | `Friend`        | フレンド関係（承認済み）          |
 | `friend_requests` | `FriendRequest` | フレンドリクエスト（申請中）      |
@@ -20,8 +20,11 @@ erDiagram
         varchar username UK "ユーザー名（一意）"
         varchar password "パスワードハッシュ（42OAuthは null）"
         varchar forty_two_id UK "42のユーザーID（オプション）"
+        varchar email "メールアドレス（nullable）GDPRメール通知用"
         boolean is_2fa_enabled "2FA有効フラグ（default: false）"
         varchar two_factor_secret "2FAシークレット（nullable）"
+        boolean is_online "オンラインステータス（default: false）"
+        timestamp last_seen_at "最終オフライン日時（nullable）"
         timestamp created_at "作成日時（自動）"
     }
 
@@ -91,6 +94,7 @@ erDiagram
 | ----------------- | -------------- | ------------------------------------------- |
 | `users`           | UNIQUE         | `username`                                  |
 | `users`           | UNIQUE         | `forty_two_id`                              |
+| `users`           | DEFAULT false  | `is_online`（ログアウト時 / サーバー起動時）|
 | `profiles`        | UNIQUE（暗黙） | `user_id`（OneToOneのため）                 |
 | `friends`         | UNIQUE         | `(user_id, friend_id)`                      |
 | `friend_requests` | ENUM           | `status`: `pending`, `accepted`, `rejected` |


### PR DESCRIPTION
## 概要

直近にマージされた実装（オンラインステータス、GDPRメール通知、WAF/ModSecurity、Vault秘密情報管理）を README と ER図ドキュメントに反映する。ドキュメントのみの変更でコードの変更はない。

---

## README に追加した内容

### 機能説明（Features セクション）
- フレンドリストへのオンラインステータスバッジ（WebSocket リアルタイム更新）
- 他ユーザーのプロフィールをモーダルで表示
- データエクスポート・アカウント削除時の GDPR メール通知
- Security / WAF セクションを新規追加（ModSecurity + OWASP CRS の説明）

### モジュール選定・ポイント計算
- Standard User Management（プロフィール・アバター・オンラインステータス・フレンド機能が IV.3 Major の要件を満たす）を追加
- WAF + Secret Management（ModSecurity と Vault を組み合わせて IV.5 Major の要件を満たす）を追加
- 合計ポイントを 19pt → 23pt に修正

### その他
- DB テーブル定義（users）に `email`, `is_online`, `last_seen_at` カラムを追記
- 環境変数に `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, `MAIL_PASS` を追記
- 個人貢献を git log の実際のコミット著者に基づいて修正

---

## docs/er-diagram.md に追加した内容

- users テーブルの Mermaid ER 図に `email`, `is_online`, `last_seen_at` を追記
- 制約一覧に `is_online` の DEFAULT false を追記